### PR TITLE
Fixed a issue that no .mo files loaded in a Rails project

### DIFF
--- a/lib/fast_gettext/translation_repository/base.rb
+++ b/lib/fast_gettext/translation_repository/base.rb
@@ -41,7 +41,7 @@ module FastGettext
           file = File.join(locale_folder,relative_file_path)
           next unless File.exist? file
           locale = File.basename(locale_folder)
-          @files[locale] = yield(locale,file)
+          yield(locale,file)
         end
       end
     end


### PR DESCRIPTION
It's a weird issue that caused by the duplicated write to `@files`, in `FastGettext::TranslationRepository::Mo#find_and_store_files` and `FastGettext::TranslationRepository::Base#find_files_in_locale_folders`. Don't really know why it works with the example app but not works with my real project, however the duplicated write should be avoided.
