### PR TITLE
FastGettext::VERSION is not accessible

### DIFF
--- a/lib/fast_gettext.rb
+++ b/lib/fast_gettext.rb
@@ -3,6 +3,7 @@ require 'fast_gettext/storage'
 require 'fast_gettext/translation'
 require 'fast_gettext/translation_repository'
 require 'fast_gettext/vendor/string'
+require 'fast_gettext/version'
 
 module FastGettext
   include FastGettext::Storage


### PR DESCRIPTION
I add the "require" for the file "lib/fast_gettext/version.rb" in  "/lib/fast_gettext.rb".

So I correct this error with the gem "gettext_i18n_rails" : 
/home/christian/.rvm/gems/ruby-1.9.3-p125@serf-console/gems/gettext_i18n_rails-0.4.5/lib/gettext_i18n_rails.rb:8:in `<top (required)>': uninitialized constant FastGettext
::VERSION (NameError)
        from /home/christian/.rvm/gems/ruby-1.9.3-p125@global/gems/bundler-1.1.1/lib/bundler/runtime.rb:68:in`require'
        from /home/christian/.rvm/gems/ruby-1.9.3-p125@global/gems/bundler-1.1.1/lib/bundler/runtime.rb:68:in `block (2 levels) in require'
        from /home/christian/.rvm/gems/ruby-1.9.3-p125@global/gems/bundler-1.1.1/lib/bundler/runtime.rb:66:in`each'
        from /home/christian/.rvm/gems/ruby-1.9.3-p125@global/gems/bundler-1.1.1/lib/bundler/runtime.rb:66:in `block in require'
        from /home/christian/.rvm/gems/ruby-1.9.3-p125@global/gems/bundler-1.1.1/lib/bundler/runtime.rb:55:in`each'
        from /home/christian/.rvm/gems/ruby-1.9.3-p125@global/gems/bundler-1.1.1/lib/bundler/runtime.rb:55:in `require'
        from /home/christian/.rvm/gems/ruby-1.9.3-p125@global/gems/bundler-1.1.1/lib/bundler.rb:119:in`require'
        from /home/christian/Dropbox/MyProjects/serf-console/config/application.rb:6:in `<top (required)>'
        from /home/christian/.rvm/gems/ruby-1.9.3-p125@serf-console/gems/railties-3.2.3/lib/rails/commands.rb:53:in`require'
        from /home/christian/.rvm/gems/ruby-1.9.3-p125@serf-console/gems/railties-3.2.3/lib/rails/commands.rb:53:in `block in <top (required)>'
        from /home/christian/.rvm/gems/ruby-1.9.3-p125@serf-console/gems/railties-3.2.3/lib/rails/commands.rb:50:in`tap'
        from /home/christian/.rvm/gems/ruby-1.9.3-p125@serf-console/gems/railties-3.2.3/lib/rails/commands.rb:50:in `<top (required)>'
        from script/rails:6:in`require'
        from script/rails:6:in `<main>'
