### PR TITLE
Make sure untranslated strings are not blank (just a spec)

### DIFF
--- a/spec/fast_gettext/po_file_spec.rb
+++ b/spec/fast_gettext/po_file_spec.rb
@@ -14,7 +14,7 @@ describe FastGettext::PoFile do
   end
 
   it "stores untranslated values as nil" do
-    de['Car|Model'].should == "Modell"
+    de['Untranslated'].should == nil
   end
 
   it "finds pluralized values" do

--- a/spec/fast_gettext/translation_spec.rb
+++ b/spec/fast_gettext/translation_spec.rb
@@ -27,6 +27,14 @@ describe FastGettext::Translation do
       _('car').should == 'Auto'
     end
 
+    it "returns the original string if its translation is blank" do
+      _('Untranslated').should == 'Untranslated'
+    end
+
+    it "does not return the blank translation if a string's translation is blank" do
+      _('Untranslated').should_not == ''
+    end
+
     it "returns key if not translation was found" do
       _('NOT|FOUND').should == 'NOT|FOUND'
     end


### PR DESCRIPTION
Just adding some specs that make sure untranslated strings are _never_ passed on as "", always as the original key.
