### PR TITLE
new line format handling

### DIFF
--- a/lib/fast_gettext/translation_repository/db_models/translation_key.rb
+++ b/lib/fast_gettext/translation_repository/db_models/translation_key.rb
@@ -8,13 +8,25 @@ class TranslationKey < ActiveRecord::Base
 
   attr_accessible :key, :translations, :translations_attributes
 
+  before_save :normalize_newlines
+
   def self.translation(key, locale)
-    return unless translation_key = find_by_key(key)
+    return unless translation_key = find_by_key(newline_normalize(key))
     return unless translation_text = translation_key.translations.find_by_locale(locale)
     translation_text.text
   end
 
   def self.available_locales
     @@available_locales ||= TranslationText.count(:group=>:locale).keys.sort
+  end
+
+  protected
+
+  def self.newline_normalize(s)
+    s.to_s.gsub("\r\n", "\n")
+  end
+
+  def normalize_newlines
+    self.key = self.class.newline_normalize(key)
   end
 end

--- a/spec/fast_gettext/translation_repository/db_spec.rb
+++ b/spec/fast_gettext/translation_repository/db_spec.rb
@@ -70,6 +70,11 @@ describe FastGettext::TranslationRepository::Db do
     @rep.plural('Axis','Axis').should == ['Achse','Achsen']
   end
 
+  it "can ignore newline format" do
+    create_translation "good\r\nmorning", "guten\r\nMorgen"
+    @rep["good\nmorning"].should == "guten\r\nMorgen"
+  end
+
   it "removes texts when key is removed" do
     t = create_translation("a", "b")
     expect{


### PR DESCRIPTION
This resolves a clash of new line formats between web (textarea) input (as seen in translation_db_engine) and plain text (or ruby code) files.
