### PR TITLE
Benchmarks can now run on Ruby 1.9 and on Mac OS X

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -8,9 +8,9 @@ task :default do
 end
 
 task :benchmark do
-  puts "Running on #{RUBY}"
+  puts "Running on #{RUBY_DESCRIPTION}"
   %w[baseline ideal fast_gettext original i18n_simple].each do |bench|
-    puts `ruby benchmark/#{bench}.rb`
+    puts `ruby -I. benchmark/#{bench}.rb`
     puts ""
   end
 end

--- a/benchmark/base.rb
+++ b/benchmark/base.rb
@@ -35,7 +35,11 @@ end
 
 def memory
   pid = Process.pid
-  map = `pmap -d #{pid}`
+  if RUBY_PLATFORM.downcase.include?("darwin")
+    map = `vmmap #{pid}`
+  else
+    map = `pmap -d #{pid}`
+  end
   map.split("\n").last.strip.squeeze(' ').split(' ')[3].to_i - DEFAULTS[:memory]
 end
 

--- a/benchmark/i18n_simple.rb
+++ b/benchmark/i18n_simple.rb
@@ -1,5 +1,17 @@
 require 'benchmark/base'
-require 'activesupport'
+
+# Try the newest ActiveSupport first, fall back to older
+begin
+  require 'active_support'
+rescue LoadError
+  begin
+    require 'activesupport'
+  rescue LoadError
+    puts 'To run this benchmark, please install the activesupport gem'
+    exit 1
+  end
+end
+
 I18n.backend = I18n::Backend::Simple.new
 I18n.load_path = ['benchmark/locale/de.yml']
 I18n.locale = :de

--- a/benchmark/locale/de.yml
+++ b/benchmark/locale/de.yml
@@ -1,4 +1,4 @@
-# German translations for Ruby on Rails 
+# German translations for Ruby on Rails
 # by Clemens Kofler (clemens@railway.at)
 
 de:
@@ -13,8 +13,7 @@ de:
     abbr_day_names: [So, Mo, Di, Mi, Do, Fr, Sa]
     month_names: [~, Januar, Februar, März, April, Mai, Juni, Juli, August, September, Oktober, November, Dezember]
     abbr_month_names: [~, Jan, Feb, Mär, Apr, Mai, Jun, Jul, Aug, Sep, Okt, Nov, Dez]
-    order: [ :day, :month, :year ]
-  
+
   time:
     formats:
       default: "%A, %e. %B %Y, %H:%M Uhr"
@@ -24,7 +23,7 @@ de:
 
     am: "vormittags"
     pm: "nachmittags"
-      
+
   datetime:
     distance_in_words:
       half_a_minute: 'eine halbe Minute'
@@ -60,7 +59,7 @@ de:
       over_x_years:
         one: 'mehr als 1 Jahr'
         other: 'mehr als {{count}} Jahre'
-      
+
   number:
     format:
       precision: 2
@@ -70,9 +69,9 @@ de:
       format:
         unit: '€'
         format: '%n%u'
-        separator: 
-        delimiter: 
-        precision: 
+        separator:
+        delimiter:
+        precision:
     percentage:
       format:
         delimiter: ""
@@ -88,7 +87,7 @@ de:
     array:
       sentence_connector: "und"
       skip_last_comma: true
-        
+
   activerecord:
     errors:
       template:

--- a/benchmark/original.rb
+++ b/benchmark/original.rb
@@ -1,10 +1,13 @@
 require 'benchmark/base'
 
 begin
-gem 'gettext', '>=2.0.0'
+  gem 'gettext', '>=2.0.0'
 rescue LoadError
-  $LOAD_PATH.unshift 'lib'
+  puts 'To run this benchmark, please install the gettext gem'
+  exit 1
 end
+
+$LOAD_PATH.unshift 'lib'
 require 'gettext'
 include GetText
 


### PR DESCRIPTION
Hi there -- thanks for fast_gettext, we're using it to get started on i18n for our site and so far we're loving it.

This PR adds the ability to run the benchmarks both with Ruby 1.9 and on Mac OSX. Some really slight changes needed to be put in for 1.9, most notably:
- 1.9 doesn't put the current directory in the load path by default we add it explicitly when running the benchmarks
- I removed a line from de.yml because Ruby 1.9's YAML parser (Psych) can't understand the symbols.

To enable OSX, we use the `vmmap` command rather than `pmap` -- fortunately, the field we're looking for is in the same place for both commands!
