### PR TITLE
Better cache expiry

### DIFF
--- a/lib/fast_gettext/translation_repository/db_models/translation_key.rb
+++ b/lib/fast_gettext/translation_repository/db_models/translation_key.rb
@@ -9,6 +9,7 @@ class TranslationKey < ActiveRecord::Base
   attr_accessible :key, :translations, :translations_attributes
 
   before_save :normalize_newlines
+  after_save :expire_cache
 
   def self.translation(key, locale)
     return unless translation_key = find_by_key(newline_normalize(key))
@@ -28,5 +29,9 @@ class TranslationKey < ActiveRecord::Base
 
   def normalize_newlines
     self.key = self.class.newline_normalize(key)
+  end
+
+  def expire_cache
+    FastGettext.expire_cache_for(key)
   end
 end

--- a/lib/fast_gettext/translation_repository/db_models/translation_text.rb
+++ b/lib/fast_gettext/translation_repository/db_models/translation_text.rb
@@ -3,11 +3,11 @@ class TranslationText < ActiveRecord::Base
   validates_presence_of :locale
   validates_uniqueness_of :locale, :scope=>:translation_key_id
   attr_accessible :text, :locale, :translation_key, :translation_key_id
-  after_update :expire_cache
+  after_save :expire_cache
 
   protected
 
   def expire_cache
-    FastGettext.expire_cache_for(translation_key.key)
+    FastGettext.expire_cache_for(translation_key.key) if translation_key.present?
   end
 end

--- a/spec/fast_gettext/translation_repository/db_spec.rb
+++ b/spec/fast_gettext/translation_repository/db_spec.rb
@@ -106,9 +106,20 @@ describe FastGettext::TranslationRepository::Db do
     translation.should_not be_accessible(:created_at)
   end
 
-  it "expires the cache when updated" do
+  it "expires the cache when a key is created " do
     FastGettext.should_receive(:expire_cache_for).with('car')
+    TranslationKey.create!(:key => 'car')
+  end
+
+  it "expires the cache when a translation is created " do
+    translation_key = TranslationKey.create!(:key => 'car')
+    FastGettext.should_receive(:expire_cache_for).with('car')
+    TranslationText.create!(:translation_key_id => translation_key.id, :text => 'Some text', :locale => "de")
+  end
+
+  it "expires the cache when a translation is updated " do
     translation_text = create_translation 'car', 'Auto'
+    FastGettext.should_receive(:expire_cache_for).with('car')
     translation_text.update_attributes :text => 'Autobot'
   end
 end


### PR DESCRIPTION
Expire the cache when database translations are created which have already been cached from an alternate source.
