### PR TITLE
Fixing issue 48

### DIFF
--- a/lib/fast_gettext/storage.rb
+++ b/lib/fast_gettext/storage.rb
@@ -122,7 +122,7 @@ module FastGettext
 
     def locale=(new_locale)
       new_locale = best_locale_in(new_locale)
-      self._locale = new_locale if new_locale
+      self._locale = new_locale
     end
 
     # for chaining: puts set_locale('xx') == 'xx' ? 'applied' : 'rejected'


### PR DESCRIPTION
if the locale= argument is invalid, let .locale return the default
locale not the previous locale

Fixes issue 48
