### PR TITLE
fixing unit test for D_

### DIFF
--- a/spec/fast_gettext/translation_spec.rb
+++ b/spec/fast_gettext/translation_spec.rb
@@ -252,7 +252,7 @@ describe FastGettext::Translation do
 
       it "sets text domain back to previous one" do
         old_domain = FastGettext.text_domain
-        D_('car').should == 'Auto'
+        D_('car').should match('(Auto|Auto 2)')
         FastGettext.text_domain.should == old_domain
       end
     end


### PR DESCRIPTION
The issue is that if it finds the translation in multiple domains, it
returns randomly (we are not sorting hash.keys for obvious reasons).

In Ruby 1.8 hash is not sorted AFAIK.
