### PR TITLE
Fix typo in Readme.md

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -81,7 +81,7 @@ Do this once in every Thread. (e.g. Rails -> ApplicationController)
     include FastGettext::Translation
     _('Car') == 'Auto'
     _('not-found') == 'not-found'
-    s_('Namespace|no-found') == 'not-found'
+    s_('Namespace|not-found') == 'not-found'
     n_('Axis','Axis',3) == 'Achsen' #German plural of Axis
     _('Hello %{name}!') % {:name => "Pete"} == 'Hello Pete!'
 


### PR DESCRIPTION
I hope I'am not the only one that uses the namespace feature, it's awesome, but this is obviously a typo. 
Cheers.
