### PR TITLE
Restore missing vendor files

### DIFF
--- a/fast_gettext.gemspec
+++ b/fast_gettext.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new name, FastGettext::VERSION do |s|
   s.authors = ["Michael Grosser"]
   s.email = "michael@grosser.it"
   s.homepage = "http://github.com/grosser/#{name}"
-  s.files = Dir["{lib/**/*.rb,Readme.md,CHANGELOG}"]
+  s.files = Dir["{lib/**/*.{rb,mo,rdoc},Readme.md,CHANGELOG}"]
   s.licenses = ["MIT", "Ruby"]
 
   s.add_development_dependency 'rake'


### PR DESCRIPTION
bb325a5 removed lib/fast_gettext/vendor/empty.mo which seems to be causing some error during usage as it's called from FastGettext::MoFile:

    File: /usr/local/rvm/gems/ruby-1.9.3-p392@test_develop_pr_core-3/gems/fast_gettext-0.9.1/lib/fast_gettext/vendor/empty.mo: No such file or directory - /usr/local/rvm/gems/ruby-1.9.3-p392@test_develop_pr_core-3/gems/fast_gettext-0.9.1/lib/fast_gettext/vendor/empty.mo (Errno::ENOENT)