### PR TITLE
Fix "MoFile.new has already been invoked and cannot be modified further"

### DIFF
--- a/spec/fast_gettext/translation_repository/mo_spec.rb
+++ b/spec/fast_gettext/translation_repository/mo_spec.rb
@@ -23,8 +23,9 @@ describe 'FastGettext::TranslationRepository::Mo' do
   describe :reload do
     before do
       mo_file = FastGettext::MoFile.new('spec/locale/de/LC_MESSAGES/test2.mo')
+      empty_mo_file = FastGettext::MoFile.empty
 
-      FastGettext::MoFile.stub(:new).and_return(FastGettext::MoFile.empty)
+      FastGettext::MoFile.stub(:new).and_return(empty_mo_file)
       FastGettext::MoFile.stub(:new).with('spec/locale/de/LC_MESSAGES/test.mo').and_return(mo_file)
     end
 


### PR DESCRIPTION
On Fedora, I observe (and ignore) following errors:

```
  1) FastGettext::TranslationRepository::Mo reload can reload
     Failure/Error: FastGettext::MoFile.stub(:new).and_return(FastGettext::MoFile.empty)
       The message expectation for FastGettext::MoFile.new has already been invoked and cannot be modified further (e.g. using `and_return`). All message expectation customizations must be applied before it is used for the first time.
     # ./spec/fast_gettext/translation_repository/mo_spec.rb:27:in `block (3 levels) in <top (required)>'

  2) FastGettext::TranslationRepository::Mo reload returns true
     Failure/Error: FastGettext::MoFile.stub(:new).and_return(FastGettext::MoFile.empty)
       The message expectation for FastGettext::MoFile.new has already been invoked and cannot be modified further (e.g. using `and_return`). All message expectation customizations must be applied before it is used for the first time.
     # ./spec/fast_gettext/translation_repository/mo_spec.rb:27:in `block (3 levels) in <top (required)>'
```

This PR avoids this issue. It is interesting that this not exhibit itself in Travis. Is it because older RSpec is used there?