### PR TITLE
Add support for zh-Hant.

### DIFF
--- a/lib/fast_gettext/storage.rb
+++ b/lib/fast_gettext/storage.rb
@@ -169,7 +169,11 @@ module FastGettext
 
     #de-de -> de_DE
     def format_locale(locale)
-      locale.sub(/^([a-zA-Z]{2,3})[-_]([a-zA-Z]{2,3})$/){$1.downcase+'_'+$2.upcase}
+      if locale =~ /^([a-zA-Z]{2})[-_]([a-zA-Z]{4})$/
+        locale.sub(/^([a-zA-Z]{2})[-_]([a-zA-Z]{4})$/) { $1.downcase+'_'+$2[0].upcase + $2[1..3] }
+      else
+        locale.sub(/^([a-zA-Z]{2,3})[-_]([a-zA-Z]{2,3})$/) { $1.downcase+'_'+$2.upcase }
+      end
     end
 
     def switch_cache

--- a/spec/fast_gettext/storage_spec.rb
+++ b/spec/fast_gettext/storage_spec.rb
@@ -356,6 +356,10 @@ describe 'Storage' do
     it "allows 3-letter locales to be formatted" do
       format_locale("gsw-ch").should == "gsw_CH"
     end
+
+    it "allows 2-letter + 4 letter locals to be formatted properly" do
+      format_locale("zh-hant").should == "zh_Hant"
+    end
   end
 
   describe :expire_cache_for do


### PR DESCRIPTION
We ran into an issue when trying to implement zh-Hant.  The format_locale didn't handle zh-Hant as a locale.