### PR TITLE
Support for lazy loading of .mo and .po files

### DIFF
--- a/lib/fast_gettext/po_file.rb
+++ b/lib/fast_gettext/po_file.rb
@@ -2,8 +2,27 @@ require 'fast_gettext/mo_file'
 module FastGettext
   # Responsibility:
   #  - abstract po files for Po Repository
-  class PoFile
+  class PoFile < MoFile
+    def initialize(file, options={})
+      @options = options
+      super
+    end
+
+    def load_data
+      if @filename.is_a? FastGettext::GetText::MOFile
+        @data = @filename
+      else
+        @data = FastGettext::PoFile.parse_po_file(@filename, @options)
+      end
+      make_singular_and_plural_available
+    end
+
     def self.to_mo_file(file, options={})
+      MoFile.new(parse_po_file(file, options))
+    end
+
+    protected
+    def self.parse_po_file(file, options={})
       require 'fast_gettext/vendor/poparser'
       parser = FastGettext::GetText::PoParser.new
 
@@ -13,7 +32,7 @@ module FastGettext
 
       mo_file = FastGettext::GetText::MOFile.new
       parser.parse(File.read(file), mo_file)
-      MoFile.new(mo_file)
+      mo_file
     end
   end
 end

--- a/lib/fast_gettext/translation_repository.rb
+++ b/lib/fast_gettext/translation_repository.rb
@@ -4,12 +4,11 @@ module FastGettext
   module TranslationRepository
     extend self
 
-    # only single-word types supported atm (mytype works, MyType will not)
     def build(name, options)
       type = options[:type] || :mo
-      class_name = type.to_s.capitalize
+      class_name = type.to_s.split('_').map(&:capitalize).join
       unless FastGettext::TranslationRepository.constants.map{|c|c.to_s}.include?(class_name)
-        require "fast_gettext/translation_repository/#{type}" 
+        require "fast_gettext/translation_repository/#{type}"
       end
       eval(class_name).new(name,options)
     end

--- a/lib/fast_gettext/translation_repository/mo.rb
+++ b/lib/fast_gettext/translation_repository/mo.rb
@@ -7,6 +7,7 @@ module FastGettext
     class Mo < Base
       def initialize(name,options={})
         super
+        @eager_load = options.fetch(:eager_load, false)
         reload
       end
 
@@ -28,7 +29,7 @@ module FastGettext
       def find_and_store_files(name,options)
         # parse all .mo files with the right name, that sit in locale/LC_MESSAGES folders
         find_files_in_locale_folders(File.join('LC_MESSAGES',"#{name}.mo"), options[:path]) do |locale,file|
-          MoFile.new(file)
+          MoFile.new(file, :eager_load => @eager_load)
         end
       end
 

--- a/lib/fast_gettext/translation_repository/po.rb
+++ b/lib/fast_gettext/translation_repository/po.rb
@@ -10,7 +10,7 @@ module FastGettext
       def find_and_store_files(name, options)
         require 'fast_gettext/po_file'
         find_files_in_locale_folders("#{name}.po", options[:path]) do |locale,file|
-          PoFile.to_mo_file(file, options)
+          PoFile.new(file, options)
         end
       end
     end

--- a/spec/fast_gettext/mo_file_spec.rb
+++ b/spec/fast_gettext/mo_file_spec.rb
@@ -2,9 +2,10 @@
 require "spec_helper"
 
 de_file = File.join('spec','locale','de','LC_MESSAGES','test.mo')
-de = FastGettext::MoFile.new(de_file)
 
 describe FastGettext::MoFile do
+  let(:de) { FastGettext::MoFile.new(de_file) }
+
   before :all do
     File.exist?(de_file).should == true
   end
@@ -28,8 +29,38 @@ describe FastGettext::MoFile do
   it "can access plurals through []" do
     de['Axis'].should == 'Achse' #singular
   end
-  
+
   it "can successfully translate non-ASCII keys" do
     de["Umläüte"].should == "Umlaute"
+  end
+
+  it "doesn't load the file when new instance is created" do
+    FastGettext::GetText::MOFile.should_not_receive(:open)
+    FastGettext::MoFile.new(de_file)
+  end
+
+  it "loads the file when a translation is touched for the first time" do
+    FastGettext::GetText::MOFile.should_receive(:open).once.with(de_file, "UTF-8").and_call_original
+
+    de['car']
+    de['car']
+  end
+
+  describe "eager loading" do
+    let(:de) { FastGettext::MoFile.new(de_file, :eager_load => true) }
+
+    it "loads the file when new instance is created" do
+      FastGettext::GetText::MOFile.should_receive(:open).once.with(de_file, "UTF-8").and_call_original
+      FastGettext::MoFile.new(de_file, :eager_load => true)
+    end
+
+    it "doesn't load the file when a translation is touched" do
+      de
+      FastGettext::GetText::MOFile.should_not_receive(:open)
+
+      de['car']
+      de['car']
+    end
+
   end
 end

--- a/spec/fast_gettext/po_file_spec.rb
+++ b/spec/fast_gettext/po_file_spec.rb
@@ -2,9 +2,10 @@ require "spec_helper"
 require 'fast_gettext/po_file'
 
 de_file = File.join('spec','locale','de','test.po')
-de = FastGettext::PoFile.to_mo_file(de_file)
 
 describe FastGettext::PoFile do
+  let(:de) { FastGettext::PoFile.new(de_file) }
+
   before :all do
     File.exist?(de_file).should == true
   end
@@ -31,5 +32,35 @@ describe FastGettext::PoFile do
 
   it "unescapes '\\'" do
     de["You should escape '\\' as '\\\\'."].should == "Du solltest '\\' als '\\\\' escapen."
+  end
+
+  it "doesn't load the file when new instance is created" do
+    File.should_not_receive(:read).with(de_file)
+    FastGettext::PoFile.new(de_file)
+  end
+
+  it "loads the file when a translation is touched for the first time" do
+    File.should_receive(:read).once.with(de_file).and_call_original
+
+    de['car']
+    de['car']
+  end
+
+  describe "eager loading" do
+    let(:de) { FastGettext::PoFile.new(de_file, :eager_load => true) }
+
+    it "loads the file when new instance is created" do
+      File.should_receive(:read).once.with(de_file).and_call_original
+      FastGettext::PoFile.new(de_file, :eager_load => true)
+    end
+
+    it "doesn't load the file when a translation is touched" do
+      de
+      File.should_not_receive(:read).with(de_file)
+
+      de['car']
+      de['car']
+    end
+
   end
 end

--- a/spec/fast_gettext/translation_repository/mo_spec.rb
+++ b/spec/fast_gettext/translation_repository/mo_spec.rb
@@ -26,7 +26,7 @@ describe 'FastGettext::TranslationRepository::Mo' do
       empty_mo_file = FastGettext::MoFile.empty
 
       FastGettext::MoFile.stub(:new).and_return(empty_mo_file)
-      FastGettext::MoFile.stub(:new).with('spec/locale/de/LC_MESSAGES/test.mo').and_return(mo_file)
+      FastGettext::MoFile.stub(:new).with('spec/locale/de/LC_MESSAGES/test.mo', :eager_load => false).and_return(mo_file)
     end
 
     it "can reload" do

--- a/spec/fast_gettext/translation_repository/po_spec.rb
+++ b/spec/fast_gettext/translation_repository/po_spec.rb
@@ -54,12 +54,14 @@ describe 'FastGettext::TranslationRepository::Po' do
   describe 'obsolete' do
     it "should warn on obsolete by default" do
       $stderr.should_receive(:print).at_least(:once)
-      FastGettext::TranslationRepository.build('test',:path=>File.join('spec','obsolete_locale'),:type=>:po)
+      repo = FastGettext::TranslationRepository.build('test',:path=>File.join('spec','obsolete_locale'),:type=>:po)
+      repo['car']
     end
 
     it "should ignore obsolete when told to do so" do
       $stderr.should_not_receive(:print)
-      FastGettext::TranslationRepository.build('test',:path=>File.join('spec','obsolete_locale'),:type=>:po, :report_warning => false)
+      repo = FastGettext::TranslationRepository.build('test',:path=>File.join('spec','obsolete_locale'),:type=>:po, :report_warning => false)
+      repo['car']
     end
   end
 end


### PR DESCRIPTION
* Adds `LazyMoFile` and `LazyMo` repo which reads .mo files when the
  translation is touched for the first time. This allows to skip loading
  unused translations and speed up application load time.
* Adds `Merge` translation repository which can serve as equivalent to
  multidomain translations in some cases. It reduces the need for
  iterating over domains when the translation is being looked up.