### PR TITLE
Support for merge repositories

### DIFF
--- a/lib/fast_gettext/mo_file.rb
+++ b/lib/fast_gettext/mo_file.rb
@@ -30,16 +30,16 @@ module FastGettext
       nil
     end
 
+    def data
+      load_data if @data.nil?
+      @data
+    end
+
     def self.empty
       MoFile.new(File.join(File.dirname(__FILE__),'vendor','empty.mo'))
     end
 
     private
-
-    def data
-      load_data if @data.nil?
-      @data
-    end
 
     def load_data
       @data = if @filename.is_a? FastGettext::GetText::MOFile

--- a/lib/fast_gettext/translation_repository/merge.rb
+++ b/lib/fast_gettext/translation_repository/merge.rb
@@ -7,12 +7,6 @@ module FastGettext
     #  - can be used instead of searching for translations in multiple domains
     #  - requires reload when current locale is changed
     class Merge < Base
-      # Only repositories with public method #data that return hash of translations are supported
-      SUPPORTED_REPO_TYPES = [
-        FastGettext::TranslationRepository::Mo,
-        FastGettext::TranslationRepository::Po
-      ]
-
       def initialize(name, options={})
         clear
         super(name, options)
@@ -64,7 +58,7 @@ module FastGettext
       protected
 
       def repo_supported?(repo)
-        SUPPORTED_REPO_TYPES.find {|c| repo.is_a?(c) }
+        repo.send(:current_translations).respond_to?(:data)
       end
 
       def load_repo(r)

--- a/lib/fast_gettext/translation_repository/merge.rb
+++ b/lib/fast_gettext/translation_repository/merge.rb
@@ -1,0 +1,76 @@
+require 'fast_gettext/translation_repository/po'
+
+module FastGettext
+  module TranslationRepository
+    # Responsibility:
+    #  - merge data from multiple repositories into one hash structure
+    #  - can be used instead of searching for translations in multiple domains
+    #  - requires reload when current locale is changed
+    class Merge < Base
+      # Only repositories with public method #data that return hash of translations are supported
+      SUPPORTED_REPO_TYPES = [
+        FastGettext::TranslationRepository::Mo,
+        FastGettext::TranslationRepository::Po
+      ]
+
+      def initialize(name, options={})
+        clear
+        super(name, options)
+      end
+
+      def available_locales
+        @repositories.flat_map { |r| r.available_locales }.uniq
+      end
+
+      def pluralisation_rule
+        @repositories.each do |r|
+          result = r.pluralisation_rule and return result
+        end
+        nil
+      end
+
+      def plural(*keys)
+        @repositories.each do |r|
+          result = r.plural(*keys)
+          return result unless result.compact.empty?
+        end
+        []
+      end
+
+      def reload
+        @data = {}
+        @repositories.each do |r|
+          load_repo(r)
+        end
+        super
+      end
+
+      def add_repo(repo)
+        raise "Unsupported repository" unless repo_supported?(repo)
+        @repositories << repo
+        load_repo(repo)
+        true
+      end
+
+      def [](key)
+        @data[key]
+      end
+
+      def clear
+        @repositories = []
+        @data = {}
+      end
+
+      protected
+
+      def repo_supported?(repo)
+        SUPPORTED_REPO_TYPES.find {|c| repo.is_a?(c) }
+      end
+
+      def load_repo(r)
+        r.reload
+        @data = r.send(:current_translations).data.merge(@data)
+      end
+    end
+  end
+end

--- a/lib/fast_gettext/translation_repository/merge.rb
+++ b/lib/fast_gettext/translation_repository/merge.rb
@@ -13,7 +13,7 @@ module FastGettext
       end
 
       def available_locales
-        @repositories.flat_map { |r| r.available_locales }.uniq
+        @repositories.flat_map(&:available_locales).uniq
       end
 
       def pluralisation_rule
@@ -34,6 +34,7 @@ module FastGettext
       def reload
         @data = {}
         @repositories.each do |r|
+          r.reload
           load_repo(r)
         end
         super
@@ -58,12 +59,11 @@ module FastGettext
       protected
 
       def repo_supported?(repo)
-        repo.send(:current_translations).respond_to?(:data)
+        repo.respond_to?(:all_translations)
       end
 
       def load_repo(r)
-        r.reload
-        @data = r.send(:current_translations).data.merge(@data)
+        @data = r.all_translations.merge(@data)
       end
     end
   end

--- a/lib/fast_gettext/translation_repository/mo.rb
+++ b/lib/fast_gettext/translation_repository/mo.rb
@@ -24,6 +24,10 @@ module FastGettext
         super
       end
 
+      def all_translations
+        current_translations.data
+      end
+
       protected
 
       def find_and_store_files(name,options)

--- a/spec/fast_gettext/translation_repository/merge_spec.rb
+++ b/spec/fast_gettext/translation_repository/merge_spec.rb
@@ -1,0 +1,136 @@
+require "spec_helper"
+
+describe 'FastGettext::TranslationRepository::Merge' do
+  describe "empty repo" do
+    before do
+      @rep = FastGettext::TranslationRepository.build('test', type: :merge)
+    end
+
+    it "has no locales" do
+      @rep.available_locales.should == []
+    end
+
+    it "cannot translate" do
+      @rep['car'].should == nil
+    end
+
+    it "cannot pluralize" do
+      @rep.plural('Axis','Axis').should == []
+    end
+
+    it "has no pluralisation rule" do
+      @rep.pluralisation_rule.should == nil
+    end
+
+    it "returns true on reload" do
+      @rep.reload.should == true
+    end
+  end
+
+  describe "filled repo" do
+    before do
+      FastGettext.locale = 'de'
+      @one = FastGettext::TranslationRepository.build('test', path: File.join('spec', 'locale'), type: :mo)
+      @two = FastGettext::TranslationRepository.build('test2', path: File.join('spec', 'locale'), type: :mo)
+
+      @rep = FastGettext::TranslationRepository.build('test', type: :merge)
+      @rep.add_repo(@one)
+      @rep.add_repo(@two)
+    end
+
+    it "builds correct repo" do
+      @rep.is_a?(FastGettext::TranslationRepository::Merge).should == true
+    end
+
+    describe "#available_locales" do
+      it "should be the sum of all added repositories" do
+        @one.should_receive(:available_locales).and_return ['de']
+        @two.should_receive(:available_locales).and_return ['de','en']
+        @rep.available_locales.should == ['de','en']
+      end
+    end
+
+    describe "#[]" do
+      it "uses the first repo for transaltion" do
+        @rep['car'].should == 'Auto'
+      end
+
+      it "returns transaltion from the second repo when it doesn't exist in the first one" do
+        @rep['Untranslated and translated in test2'].should == 'Translated'
+      end
+    end
+
+    describe "#add_repo" do
+      it "accepts mo repository" do
+        mo_rep = FastGettext::TranslationRepository.build('test', path: File.join('spec', 'locale'), type: :mo)
+        @rep.add_repo(mo_rep).should == true
+      end
+
+      it "accepts po repository" do
+        po_rep = FastGettext::TranslationRepository.build('test', path: File.join('spec', 'locale'), type: :po)
+        @rep.add_repo(po_rep).should == true
+      end
+
+      it "raises exeption for other repositories" do
+        base_rep = FastGettext::TranslationRepository.build('test', path: File.join('spec', 'locale'), type: :base)
+        lambda { @rep.add_repo(base_rep) }.should raise_error(RuntimeError)
+      end
+    end
+
+    describe "#plural" do
+      it "uses the first repo in the chain if it responds" do
+        @one.should_receive(:plural).with('a','b').and_return ['A','B']
+        @rep.plural('a','b').should == ['A','B']
+      end
+
+      it "uses the second repo in the chain if the first does not respond" do
+        @one.should_receive(:plural).with('a','b').and_return []
+        @two.should_receive(:plural).with('a','b').and_return ['A','B']
+        @rep.plural('a','b').should == ['A','B']
+      end
+
+      it "returns empty array if no plural is faound" do
+        @one.should_receive(:plural).with('a','b').and_return []
+        @two.should_receive(:plural).with('a','b').and_return []
+        @rep.plural('a','b').should == []
+      end
+    end
+
+    describe "#pluralisation_rule" do
+      it "chooses the first that exists" do
+        @one.should_receive(:pluralisation_rule).and_return nil
+        @two.should_receive(:pluralisation_rule).and_return 'x'
+        @rep.pluralisation_rule.should == 'x'
+      end
+    end
+
+    describe "#reload" do
+      before do
+        @rep = FastGettext::TranslationRepository.build('test', type: :merge)
+        @rep.add_repo(FastGettext::TranslationRepository.build('test', path: File.join('spec', 'locale'), type: :mo))
+        @rep['Untranslated and translated in test2'].should be_nil
+
+        mo_file = FastGettext::MoFile.new('spec/locale/de/LC_MESSAGES/test2.mo')
+        empty_mo_file = FastGettext::MoFile.empty
+
+        FastGettext::MoFile.stub(:new).and_return(empty_mo_file)
+        FastGettext::MoFile.stub(:new).with('spec/locale/de/LC_MESSAGES/test.mo', eager_load: false).and_return(mo_file)
+      end
+
+      it "can reload" do
+        @rep.reload
+        @rep['Untranslated and translated in test2'].should == 'Translated'
+      end
+
+      it "returns true" do
+        @rep.reload.should == true
+      end
+    end
+  end
+
+  it "can work in SAFE mode" do
+    pending_if RUBY_VERSION > "2.0" do
+      `ruby spec/cases/safe_mode_can_handle_locales.rb 2>&1`.should == 'true'
+    end
+  end
+end

--- a/spec/fast_gettext/translation_repository/merge_spec.rb
+++ b/spec/fast_gettext/translation_repository/merge_spec.rb
@@ -3,27 +3,27 @@ require "spec_helper"
 describe 'FastGettext::TranslationRepository::Merge' do
   describe "empty repo" do
     before do
-      @rep = FastGettext::TranslationRepository.build('test', type: :merge)
+      @repo = FastGettext::TranslationRepository.build('test', type: :merge)
     end
 
     it "has no locales" do
-      @rep.available_locales.should == []
+      @repo.available_locales.should == []
     end
 
     it "cannot translate" do
-      @rep['car'].should == nil
+      @repo['car'].should == nil
     end
 
     it "cannot pluralize" do
-      @rep.plural('Axis','Axis').should == []
+      @repo.plural('Axis','Axis').should == []
     end
 
     it "has no pluralisation rule" do
-      @rep.pluralisation_rule.should == nil
+      @repo.pluralisation_rule.should == nil
     end
 
     it "returns true on reload" do
-      @rep.reload.should == true
+      @repo.reload.should == true
     end
   end
 
@@ -33,67 +33,66 @@ describe 'FastGettext::TranslationRepository::Merge' do
       @one = FastGettext::TranslationRepository.build('test', path: File.join('spec', 'locale'), type: :mo)
       @two = FastGettext::TranslationRepository.build('test2', path: File.join('spec', 'locale'), type: :mo)
 
-      @rep = FastGettext::TranslationRepository.build('test', type: :merge)
-      @rep.add_repo(@one)
-      @rep.add_repo(@two)
+      @repo = FastGettext::TranslationRepository.build('test', type: :merge)
+      @repo.add_repo(@one)
+      @repo.add_repo(@two)
     end
 
     it "builds correct repo" do
-      @rep.is_a?(FastGettext::TranslationRepository::Merge).should == true
+      @repo.is_a?(FastGettext::TranslationRepository::Merge).should == true
     end
 
     describe "#available_locales" do
       it "should be the sum of all added repositories" do
         @one.should_receive(:available_locales).and_return ['de']
         @two.should_receive(:available_locales).and_return ['de','en']
-        @rep.available_locales.should == ['de','en']
+        @repo.available_locales.should == ['de','en']
       end
     end
 
     describe "#[]" do
       it "uses the first repo for transaltion" do
-        @rep['car'].should == 'Auto'
+        @repo['car'].should == 'Auto'
       end
 
       it "returns transaltion from the second repo when it doesn't exist in the first one" do
-        @rep['Untranslated and translated in test2'].should == 'Translated'
+        @repo['Untranslated and translated in test2'].should == 'Translated'
       end
     end
 
     describe "#add_repo" do
       it "accepts mo repository" do
         mo_rep = FastGettext::TranslationRepository.build('test', path: File.join('spec', 'locale'), type: :mo)
-        @rep.add_repo(mo_rep).should == true
+        @repo.add_repo(mo_rep).should == true
       end
 
       it "accepts po repository" do
         po_rep = FastGettext::TranslationRepository.build('test', path: File.join('spec', 'locale'), type: :po)
-        @rep.add_repo(po_rep).should == true
+        @repo.add_repo(po_rep).should == true
       end
 
       it "raises exeption for other repositories" do
         unsupported_rep = FastGettext::TranslationRepository.build('test', path: File.join('spec', 'locale'), type: :base)
-        unsupported_rep.should_receive(:current_translations).at_least(1).and_return(Object.new)
-        lambda { @rep.add_repo(unsupported_rep) }.should raise_error(RuntimeError)
+        lambda { @repo.add_repo(unsupported_rep) }.should raise_error(RuntimeError)
       end
     end
 
     describe "#plural" do
       it "uses the first repo in the chain if it responds" do
         @one.should_receive(:plural).with('a','b').and_return ['A','B']
-        @rep.plural('a','b').should == ['A','B']
+        @repo.plural('a','b').should == ['A','B']
       end
 
       it "uses the second repo in the chain if the first does not respond" do
         @one.should_receive(:plural).with('a','b').and_return []
         @two.should_receive(:plural).with('a','b').and_return ['A','B']
-        @rep.plural('a','b').should == ['A','B']
+        @repo.plural('a','b').should == ['A','B']
       end
 
       it "returns empty array if no plural is faound" do
         @one.should_receive(:plural).with('a','b').and_return []
         @two.should_receive(:plural).with('a','b').and_return []
-        @rep.plural('a','b').should == []
+        @repo.plural('a','b').should == []
       end
     end
 
@@ -101,15 +100,15 @@ describe 'FastGettext::TranslationRepository::Merge' do
       it "chooses the first that exists" do
         @one.should_receive(:pluralisation_rule).and_return nil
         @two.should_receive(:pluralisation_rule).and_return 'x'
-        @rep.pluralisation_rule.should == 'x'
+        @repo.pluralisation_rule.should == 'x'
       end
     end
 
     describe "#reload" do
       before do
-        @rep = FastGettext::TranslationRepository.build('test', type: :merge)
-        @rep.add_repo(FastGettext::TranslationRepository.build('test', path: File.join('spec', 'locale'), type: :mo))
-        @rep['Untranslated and translated in test2'].should be_nil
+        @repo = FastGettext::TranslationRepository.build('test', type: :merge)
+        @repo.add_repo(FastGettext::TranslationRepository.build('test', path: File.join('spec', 'locale'), type: :mo))
+        @repo['Untranslated and translated in test2'].should be_nil
 
         mo_file = FastGettext::MoFile.new('spec/locale/de/LC_MESSAGES/test2.mo')
         empty_mo_file = FastGettext::MoFile.empty
@@ -119,12 +118,12 @@ describe 'FastGettext::TranslationRepository::Merge' do
       end
 
       it "can reload" do
-        @rep.reload
-        @rep['Untranslated and translated in test2'].should == 'Translated'
+        @repo.reload
+        @repo['Untranslated and translated in test2'].should == 'Translated'
       end
 
       it "returns true" do
-        @rep.reload.should == true
+        @repo.reload.should == true
       end
     end
   end

--- a/spec/fast_gettext/translation_repository/merge_spec.rb
+++ b/spec/fast_gettext/translation_repository/merge_spec.rb
@@ -72,8 +72,9 @@ describe 'FastGettext::TranslationRepository::Merge' do
       end
 
       it "raises exeption for other repositories" do
-        base_rep = FastGettext::TranslationRepository.build('test', path: File.join('spec', 'locale'), type: :base)
-        lambda { @rep.add_repo(base_rep) }.should raise_error(RuntimeError)
+        unsupported_rep = FastGettext::TranslationRepository.build('test', path: File.join('spec', 'locale'), type: :base)
+        unsupported_rep.should_receive(:current_translations).at_least(1).and_return(Object.new)
+        lambda { @rep.add_repo(unsupported_rep) }.should raise_error(RuntimeError)
       end
     end
 


### PR DESCRIPTION
Adds `Merge` translation repository which can serve as equivalent to multidomain translations in some cases. It reduces the need for iterating over domains when the translation is being looked up.