### PR TITLE
Expose name and options on TranslationRepository

### DIFF
--- a/lib/fast_gettext/translation_repository/base.rb
+++ b/lib/fast_gettext/translation_repository/base.rb
@@ -4,6 +4,9 @@ module FastGettext
     #  - base for all repositories
     #  - fallback as empty repository, that cannot translate anything but does not crash
     class Base
+
+      attr_accessor :name, :options
+
       def initialize(name,options={})
         @name = name
         @options = options

--- a/lib/fast_gettext/translation_repository/base.rb
+++ b/lib/fast_gettext/translation_repository/base.rb
@@ -5,7 +5,7 @@ module FastGettext
     #  - fallback as empty repository, that cannot translate anything but does not crash
     class Base
 
-      attr_accessor :name, :options
+      attr_reader :name, :options
 
       def initialize(name,options={})
         @name = name

--- a/spec/fast_gettext/translation_repository_spec.rb
+++ b/spec/fast_gettext/translation_repository_spec.rb
@@ -17,5 +17,14 @@ describe FastGettext::TranslationRepository do
       repo.name.should == 'xx'
       repo.options.should == options
     end
+
+    it "exposes name and options for reading" do
+      options = { :type => 'base' }
+      repo = FastGettext::TranslationRepository.build('xx', options)
+      repo.should respond_to(:name)
+      repo.should_not respond_to(:name=)
+      repo.should respond_to(:options)
+      repo.should_not respond_to(:options=)
+    end
   end
 end

--- a/spec/fast_gettext/translation_repository_spec.rb
+++ b/spec/fast_gettext/translation_repository_spec.rb
@@ -1,17 +1,5 @@
 require "spec_helper"
 
-module FastGettext
-  module TranslationRepository
-    class Dummy
-      attr_accessor :name, :options
-      def initialize(name, options)
-        @name = name
-        @options = options
-      end
-    end
-  end
-end
-
 describe FastGettext::TranslationRepository do
   describe "build" do
     it "auto requires class by default" do
@@ -19,13 +7,13 @@ describe FastGettext::TranslationRepository do
     end
 
     it "can have auto-require disabled" do
-      FastGettext::TranslationRepository.build('xx', { :type => 'dummy' })
+      FastGettext::TranslationRepository.build('xx', { :type => 'base' })
     end
 
     it "makes a new repository" do
-      options = { :type => 'dummy', :external => true }
+      options = { :type => 'base', :external => true }
       repo = FastGettext::TranslationRepository.build('xx', options)
-      repo.class.should == FastGettext::TranslationRepository::Dummy
+      repo.class.should == FastGettext::TranslationRepository::Base
       repo.name.should == 'xx'
       repo.options.should == options
     end


### PR DESCRIPTION
Would like to be able to access these things which would be helpful when creating repo chains. This adds an attribute accessor for both instance variables.

e.g.
```ruby
def self.chain_contains?(repository)
    @@translation_repositories.each do |in_chain|
      return true if repository.instance_variable_get(:@name) == in_chain.instance_variable_get(:@name)
    end
    false
end
```