### PR TITLE
Add reload method to Db TranslationRepository

### DIFF
--- a/lib/fast_gettext/translation_repository/db.rb
+++ b/lib/fast_gettext/translation_repository/db.rb
@@ -47,6 +47,10 @@ module FastGettext
         end
       end
 
+      def reload
+        true
+      end
+
       def self.require_models
         folder = "fast_gettext/translation_repository/db_models"
         require "#{folder}/translation_key"

--- a/spec/fast_gettext/storage_spec.rb
+++ b/spec/fast_gettext/storage_spec.rb
@@ -307,6 +307,13 @@ describe 'Storage' do
       FastGettext.reload!
     end
 
+    it "works with DB repository" do
+      db = FastGettext::TranslationRepository::Db.new('x', :model=>TranslationKey)
+      self.translation_repositories[:db] = db
+
+      FastGettext.reload!
+    end
+
     it "clears the cache" do
       FastGettext.cache.should_receive(:reload!)
 

--- a/spec/fast_gettext/translation_repository/db_spec.rb
+++ b/spec/fast_gettext/translation_repository/db_spec.rb
@@ -69,6 +69,10 @@ describe FastGettext::TranslationRepository::Db do
     @rep.plural('Axis','Axis').should == ['Achse','Achsen']
   end
 
+  it "can reload" do
+    @rep.reload.should == true
+  end
+
   it "can ignore newline format" do
     create_translation "good\r\nmorning", "guten\r\nMorgen"
     @rep["good\nmorning"].should == "guten\r\nMorgen"


### PR DESCRIPTION
This prevents an error caused by calling `FastGettext.reload!` if you have DB repository 