### PR TITLE
Change threadsave to threadsafe

### DIFF
--- a/lib/fast_gettext/storage.rb
+++ b/lib/fast_gettext/storage.rb
@@ -2,7 +2,7 @@ require 'fast_gettext/cache'
 
 module FastGettext
   # Responsibility:
-  #  - store data threadsave
+  #  - store data threadsafe
   #  - provide error messages when repositories are unconfigured
   #  - accept/reject locales that are set by the user
   module Storage


### PR DESCRIPTION
Fixed typo error `threadsave` to `threadsafe`. There are also typo error in project description.