### PR TITLE
Fix PoFile.parse_po_file to correctly utilize encoding detection

### DIFF
--- a/lib/fast_gettext/po_file.rb
+++ b/lib/fast_gettext/po_file.rb
@@ -32,7 +32,7 @@ module FastGettext
       parser.report_warning = options.fetch(:report_warning, true)
 
       mo_file = FastGettext::GetText::MOFile.new
-      parser.parse(File.read(file), mo_file)
+      parser.parse_file(file, mo_file)
       mo_file
     end
   end

--- a/lib/fast_gettext/vendor/poparser.rb
+++ b/lib/fast_gettext/vendor/poparser.rb
@@ -132,14 +132,9 @@ module GetText
   end
 
   def parse_file(po_file, data)
-    args = [ po_file ]
-    # In Ruby 1.9, we must detect proper encoding of a PO file.
-    if String.instance_methods.include?(:encode)
-      encoding = detect_file_encoding(po_file)
-      args << "r:#{encoding}"
-    end
     @po_file = po_file
-    parse(File.open(*args) {|io| io.read }, data)
+    encoding = detect_file_encoding(po_file)
+    parse(File.open(po_file, "r:#{encoding}") {|io| io.read }, data)
   end
 
   def detect_file_encoding(po_file)

--- a/spec/fast_gettext/po_file_spec.rb
+++ b/spec/fast_gettext/po_file_spec.rb
@@ -35,12 +35,12 @@ describe FastGettext::PoFile do
   end
 
   it "doesn't load the file when new instance is created" do
-    File.should_not_receive(:read).with(de_file)
+    File.should_not_receive(:open).with(de_file, "r:UTF-8")
     FastGettext::PoFile.new(de_file)
   end
 
   it "loads the file when a translation is touched for the first time" do
-    File.should_receive(:read).once.with(de_file).and_call_original
+    File.should_receive(:open).once.with(de_file, "r:UTF-8").and_call_original
 
     de['car']
     de['car']
@@ -50,13 +50,13 @@ describe FastGettext::PoFile do
     let(:de) { FastGettext::PoFile.new(de_file, :eager_load => true) }
 
     it "loads the file when new instance is created" do
-      File.should_receive(:read).once.with(de_file).and_call_original
+      File.should_receive(:open).once.with(de_file, "r:UTF-8").and_call_original
       FastGettext::PoFile.new(de_file, :eager_load => true)
     end
 
     it "doesn't load the file when a translation is touched" do
       de
-      File.should_not_receive(:read).with(de_file)
+      File.should_not_receive(:open).with(de_file, "r:UTF-8")
 
       de['car']
       de['car']


### PR DESCRIPTION
Naked File.read() calls do not correctly detect the encoding of the loaded PO file. The parse_file method already has support for that, so use that instead.

Additionally, this removes the 1.8/1.9 compatibility bridge in parse_file, which is not required anymore.