### PR TITLE
IO#lines has been deprecated in Ruby 2.0 in favor of IO#each_line

### DIFF
--- a/lib/fast_gettext/vendor/poparser.rb
+++ b/lib/fast_gettext/vendor/poparser.rb
@@ -139,7 +139,7 @@ module GetText
 
   def detect_file_encoding(po_file)
     open(po_file, :encoding => 'ASCII-8BIT') do |input|
-      input.lines.each do |line|
+      input.each_line do |line|
         return Encoding.find($1) if %r["Content-Type:.*\scharset=(.*)\\n"] =~ line
       end
     end


### PR DESCRIPTION
A deprecation warning is currently displayed with Ruby 2.4.

IO#each_line is available in Ruby 1.8 and up, so this should not break anything.