### PR TITLE
Do not use a relative path for require, as it fails with safe mode enabled

### DIFF
--- a/lib/fast_gettext/translation_repository.rb
+++ b/lib/fast_gettext/translation_repository.rb
@@ -2,13 +2,18 @@ module FastGettext
   # Responsibility:
   #  - decide which repository to choose from given input
   module TranslationRepository
+    VALID_TYPES = %i[base chain db logger merge mo po yaml].freeze
+
     extend self
 
     def build(name, options)
-      type = options[:type] || :mo
+      type = options[:type] ? options[:type].to_sym : :mo
+
+      raise ArgumentError, "Invalid translation repository type" unless VALID_TYPES.include?(type)
+
       class_name = type.to_s.split('_').map(&:capitalize).join
       unless FastGettext::TranslationRepository.constants.map{|c|c.to_s}.include?(class_name)
-        require "fast_gettext/translation_repository/#{type}"
+        require "#{__dir__}/translation_repository/#{type}.rb".untaint
       end
       eval(class_name).new(name,options)
     end

--- a/spec/fast_gettext/translation_repository/merge_spec.rb
+++ b/spec/fast_gettext/translation_repository/merge_spec.rb
@@ -138,8 +138,6 @@ describe 'FastGettext::TranslationRepository::Merge' do
   end
 
   it "can work in SAFE mode" do
-    pending_if RUBY_VERSION > "2.0" do
-      `ruby spec/cases/safe_mode_can_handle_locales.rb 2>&1`.should == 'true'
-    end
+    `ruby spec/cases/safe_mode_can_handle_locales.rb 2>&1`.should == 'true'
   end
 end

--- a/spec/fast_gettext/translation_repository/mo_spec.rb
+++ b/spec/fast_gettext/translation_repository/mo_spec.rb
@@ -52,8 +52,6 @@ describe 'FastGettext::TranslationRepository::Mo' do
   end
 
   it "can work in SAFE mode" do
-    pending_if RUBY_VERSION > "2.0" do
-      `ruby spec/cases/safe_mode_can_handle_locales.rb 2>&1`.should == 'true'
-    end
+    `ruby spec/cases/safe_mode_can_handle_locales.rb 2>&1`.should == 'true'
   end
 end

--- a/spec/fast_gettext/translation_repository_spec.rb
+++ b/spec/fast_gettext/translation_repository_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 describe FastGettext::TranslationRepository do
   describe "build" do
     it "auto requires class by default" do
-      lambda { FastGettext::TranslationRepository.build('xx', { :type => 'invalid'}) }.should raise_error(LoadError)
+      lambda { FastGettext::TranslationRepository.build('xx', { :type => 'invalid'}) }.should raise_error(ArgumentError)
     end
 
     it "can have auto-require disabled" do


### PR DESCRIPTION
This fixes the two specs marked as pending on Ruby 2.x.

I am not 100% sure here about the relative path. Are there some wanted cases where the previous require will require another file when using the `LOAD_PATH`?

`__dir__` and `%i[]` are only available in Ruby 2.x. I do not think this will be a problem.