### PR TITLE
Preserve Ruby 1.8 compatibility

### DIFF
--- a/lib/fast_gettext/vendor/poparser.rb
+++ b/lib/fast_gettext/vendor/poparser.rb
@@ -132,9 +132,14 @@ module GetText
   end
 
   def parse_file(po_file, data)
+    args = [ po_file ]
+    # We should not try to detect the string encoding in Ruby 1.8
+    if String.instance_methods.include?(:encode)
+      encoding = detect_file_encoding(po_file)
+      args << "r:#{encoding}"
+    end
     @po_file = po_file
-    encoding = detect_file_encoding(po_file)
-    parse(File.open(po_file, "r:#{encoding}") {|io| io.read }, data)
+    parse(File.open(*args) {|io| io.read }, data)
   end
 
   def detect_file_encoding(po_file)

--- a/spec/fast_gettext/po_file_spec.rb
+++ b/spec/fast_gettext/po_file_spec.rb
@@ -4,6 +4,14 @@ require 'fast_gettext/po_file'
 de_file = File.join('spec','locale','de','test.po')
 
 describe FastGettext::PoFile do
+  let(:open_args) {
+    if RUBY_VERSION < "1.9"
+      [ de_file]
+    else
+      [ de_file, "r:UTF-8" ]
+    end
+  }
+
   let(:de) { FastGettext::PoFile.new(de_file) }
 
   before :all do
@@ -35,12 +43,12 @@ describe FastGettext::PoFile do
   end
 
   it "doesn't load the file when new instance is created" do
-    File.should_not_receive(:open).with(de_file, "r:UTF-8")
+    File.should_not_receive(:open).with(*open_args)
     FastGettext::PoFile.new(de_file)
   end
 
   it "loads the file when a translation is touched for the first time" do
-    File.should_receive(:open).once.with(de_file, "r:UTF-8").and_call_original
+    File.should_receive(:open).once.with(*open_args).and_call_original
 
     de['car']
     de['car']
@@ -50,13 +58,13 @@ describe FastGettext::PoFile do
     let(:de) { FastGettext::PoFile.new(de_file, :eager_load => true) }
 
     it "loads the file when new instance is created" do
-      File.should_receive(:open).once.with(de_file, "r:UTF-8").and_call_original
+      File.should_receive(:open).once.with(*open_args).and_call_original
       FastGettext::PoFile.new(de_file, :eager_load => true)
     end
 
     it "doesn't load the file when a translation is touched" do
       de
-      File.should_not_receive(:open).with(de_file, "r:UTF-8")
+      File.should_not_receive(:open).with(*open_args)
 
       de['car']
       de['car']

--- a/spec/fast_gettext/translation_repository/mo_spec.rb
+++ b/spec/fast_gettext/translation_repository/mo_spec.rb
@@ -53,7 +53,8 @@ describe 'FastGettext::TranslationRepository::Mo' do
 
   it "can work in SAFE mode" do
     pending_if RUBY_VERSION > "2.0" do
-      `ruby spec/cases/safe_mode_can_handle_locales.rb 2>&1`.should == 'true'
+      # On Ruby Enterprise Edition, this script emits some warnings along with 'true'
+      `ruby spec/cases/safe_mode_can_handle_locales.rb 2>&1`.should =~ /true/
     end
   end
 end


### PR DESCRIPTION
This commit updates the file encoding detection to only be performed on
Ruby 1.9 and above, and updates the specs accordingly, so they expect
the correct arguments. This is preserver compatibility with Ruby
Enterprise Edition and Ruby 1.8.7.