### PR TITLE
Extract locale from file name when they are formated as `some.topic.qq.yml`

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -67,6 +67,8 @@ FastGettext.add_text_domain('my_app', path: 'locale', type: :po)
 Or yaml files (use I18n syntax/indentation)
 
 ```Ruby
+# A single locale can be segmented in multiple yaml files but they all should be
+# named with a `qq.yml` suffix, where `qq` is the locale name.
 FastGettext.add_text_domain('my_app', path: 'config/locales', type: :yaml)
 ```
 

--- a/lib/fast_gettext/translation_repository/yaml.rb
+++ b/lib/fast_gettext/translation_repository/yaml.rb
@@ -44,7 +44,8 @@ module FastGettext
           # that is, we suppose it to be named `qq.yml` or `foo.qq.yml` where
           # `qq` stands for a locale name
           locale = File.basename(yaml_file, '.yml').split('.').last
-          @files[locale] = load_yaml(yaml_file, locale)
+          @files[locale] ||= {}
+          @files[locale].merge! load_yaml(yaml_file, locale)
         end
       end
 

--- a/lib/fast_gettext/translation_repository/yaml.rb
+++ b/lib/fast_gettext/translation_repository/yaml.rb
@@ -39,11 +39,11 @@ module FastGettext
         @files = {}
         path = options[:path] || 'config/locales'
         Dir["#{path}/*.yml"].each do |yaml_file|
-          # only take into account the first dot separeted part of the file name
-          # which matches an authorized locale code
-          locale = (File.basename(yaml_file, '.yml').split('.') &
-            FastGettext.default_available_locales).first
-
+          # Only take into account the last dot separeted part of the file name,
+          # excluding the extension file name
+          # that is, we suppose it to be named `qq.yml` or `foo.qq.yml` where
+          # `qq` stands for a locale name
+          locale = (File.basename(yaml_file, '.yml').split('.').last
           @files[locale] = load_yaml(yaml_file, locale)
         end
       end

--- a/lib/fast_gettext/translation_repository/yaml.rb
+++ b/lib/fast_gettext/translation_repository/yaml.rb
@@ -43,7 +43,7 @@ module FastGettext
           # excluding the extension file name
           # that is, we suppose it to be named `qq.yml` or `foo.qq.yml` where
           # `qq` stands for a locale name
-          locale = (File.basename(yaml_file, '.yml').split('.').last
+          locale = File.basename(yaml_file, '.yml').split('.').last
           @files[locale] = load_yaml(yaml_file, locale)
         end
       end

--- a/lib/fast_gettext/translation_repository/yaml.rb
+++ b/lib/fast_gettext/translation_repository/yaml.rb
@@ -44,8 +44,7 @@ module FastGettext
           # that is, we suppose it to be named `qq.yml` or `foo.qq.yml` where
           # `qq` stands for a locale name
           locale = File.basename(yaml_file, '.yml').split('.').last
-          @files[locale] ||= {}
-          @files[locale].merge! load_yaml(yaml_file, locale)
+          (@files[locale] ||= {}).merge! load_yaml(yaml_file, locale)
         end
       end
 

--- a/lib/fast_gettext/translation_repository/yaml.rb
+++ b/lib/fast_gettext/translation_repository/yaml.rb
@@ -39,7 +39,11 @@ module FastGettext
         @files = {}
         path = options[:path] || 'config/locales'
         Dir["#{path}/*.yml"].each do |yaml_file|
-          locale = File.basename(yaml_file, '.yml')
+          # only take into account the first dot separeted part of the file name
+          # which matches an authorized locale code
+          locale = (File.basename(yaml_file, '.yml').split('.') &
+            FastGettext.default_available_locales).first
+
           @files[locale] = load_yaml(yaml_file, locale)
         end
       end

--- a/spec/fast_gettext/translation_repository/yaml_spec.rb
+++ b/spec/fast_gettext/translation_repository/yaml_spec.rb
@@ -12,6 +12,13 @@ describe 'FastGettext::TranslationRepository::Yaml' do
     @rep.available_locales.sort.should == ['de', 'en', 'zh_CN']
   end
 
+  it "accumulates segmented locales" do
+    FastGettext.locale = 'en'
+    locales = @rep.send(:current_translations)
+    locales['simple'].should == 'easy'
+    locales['additional'].should == 'validate'
+  end
+
   it "translates nothing when locale is unsupported" do
     FastGettext.locale = 'xx'
     @rep['simple'].should == nil

--- a/spec/locale/yaml/valid/additional.en.yml
+++ b/spec/locale/yaml/valid/additional.en.yml
@@ -1,0 +1,2 @@
+en:
+  additional: validate


### PR DESCRIPTION
Previously FastGettext would only handle file named `qq.yml`