### PR TITLE
Implement p_ method

### DIFF
--- a/lib/fast_gettext/translation.rb
+++ b/lib/fast_gettext/translation.rb
@@ -42,6 +42,14 @@ module FastGettext
       end
     end
 
+    #translate with namespace, use namespect to find key
+    # 'Car','Tire' -> Tire if no translation could be found
+    # p_('Car','Tire') <=> s_('Car|Tire')
+    def p_(namespace, key, separator=nil, &block)
+      msgid = "#{namespace}#{separator||NAMESPACE_SEPARATOR}#{key}"
+      FastGettext.cached_find(msgid) or (block ? block.call : key)
+    end
+
     #translate, but discard namespace if nothing was found
     # Car|Tire -> Tire if no translation could be found
     def s_(key, separator=nil, &block)

--- a/spec/fast_gettext/translation_spec.rb
+++ b/spec/fast_gettext/translation_spec.rb
@@ -100,6 +100,16 @@ describe FastGettext::Translation do
     end
   end
 
+  describe :p_ do
+    it "returns key if a translation was not found" do
+      p_("XXX","not found").should == "not found"
+    end
+
+    it "returns block when specified" do
+      p_("XXX",'not found'){:block}.should == :block
+    end
+  end
+
   describe :s_ do
     it "translates simple text" do
       s_('car').should == 'Auto'
@@ -311,6 +321,7 @@ describe FastGettext::Translation do
       before do
         #singular cache keys
         FastGettext.cache['xxx'] = '1'
+        FastGettext.cache['zzz|qqq'] = '3'
 
         #plural cache keys
         FastGettext.cache['||||xxx'] = ['1','2']
@@ -319,6 +330,10 @@ describe FastGettext::Translation do
 
       it "uses the cache when translating with _" do
         _('xxx').should == '1'
+      end
+
+      it "uses the cache when translating with p_" do
+        p_('zzz','qqq').should == '3'
       end
 
       it "uses the cache when translating with s_" do


### PR DESCRIPTION
This implements the `p_('car','tire')` as an alternative syntax to `s_('car|tire')`
