### PR TITLE
Parity with ruby gettext translation methods

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -92,14 +92,84 @@ FastGettext.locale = 'de'
 
 ### 4. Start translating
 
-```Ruby
+FastGetText supports all the translation methods of [ruby-gettext](http://github.com/ruby-gettext/gettext) with added support for block defaults.
+
+#### `_()` or `gettext()`: basic translation
+
+```ruby
 include FastGettext::Translation
-_('Car') == 'Auto'
-_('not-found') == 'not-found'
-s_('Namespace|not-found') == 'not-found'
-n_('Axis','Axis',3) == 'Achsen' #German plural of Axis
-_('Hello %{name}!') % {name: "Pete"} == 'Hello Pete!'
+_('Car') == 'Auto'             # found translation for 'Car'
+_('not-found') == 'not-found'  # The msgid is returned by default
 ```
+
+#### `n_()` or `ngettext()`: pluralization
+
+```ruby
+n_('Car','Cars',1) == 'Auto'
+n_('Car','Cars',2) == 'Autos' #German plural of Cars
+n_(['Car','Cars'],2) == 'Autos' # Alternate 2 arg variation
+```
+
+You'll often want to interpolate the results of `n_()` using ruby builtin `%` operator.
+
+```ruby
+n_('Car','#{n} Cars',2) % { n: count } == '2 Autos'
+```
+
+
+#### `p_()` or `pgettext()`: context-aware
+
+```ruby
+p_('File','Open') == "öffnen"
+p_('Context','not-found') == 'not-found'
+```
+
+#### `s_()` or `sgetext()`: without context
+
+````ruby
+s_('File|Open') == "öffnen"
+s_('Context|not-found') == 'not-found'
+```
+
+The difference between `s_()` and `p_()` is largely based on how the translations
+are stored. Your preference will be based on your workflow and translation editing
+tools.
+
+#### `pn_()` or `pngettext()`: context-aware pluralized
+
+```ruby
+pn_('Fruit','Apple','Apples', 3) == 'Äpfel'
+pn_('Fruit','Apple','Apples', 1) == 'Apfel'
+pn_(['Fruit','Apple','Apples'], 1) == 'Apfel' # 2 arg variation
+```
+
+#### `sn_()` or `sngettext()`: without context pluralized
+
+```ruby
+sn_('Fruit|Apple','Apples', 3) == 'Äpfel'
+sn_('Fruit|Apple','Apples', 1) == 'Apfel'
+sn_(['Fruit|Apple','Apples'], 1) == 'Apfel' # 2 arg variation
+```
+
+#### `N_()` and `Nn_()`: make dynamic translations available to the parser.
+
+In many instances, your strings will not be found the by the ruby-parse. These methods
+allow for those strings to be discovered.
+
+```
+N_("active"); N_("inactive"); N_("paused") # possible value of status for parser to find.
+Nn_("active","inactive","paused")          # alternative method
+_("Your account is #{account_state}.") % { account_state: status }
+```
+
+#### Block defaults
+
+All the translation methods also support a block default, a feature not provided by ruby-gettext
+
+```ruby
+_('not-found'){ "alternative default" } == alternate default
+```
+
 
 
 Managing translations
@@ -113,7 +183,7 @@ Tell Gettext where your .mo or .po files lie, e.g. for locale/de/my_app.po and l
 FastGettext.add_text_domain('my_app', path: 'locale')
 ```
 
-Use the [original GetText](http://github.com/mutoh/gettext) to create and manage po/mo-files.
+Use the [original GetText](http://github.com/ruby-gettext/gettext) to create and manage po/mo-files.
 (Work on a po/mo parser & reader that is easier to use has started, contributions welcome @ [get_pomo](http://github.com/grosser/get_pomo) )
 
 ### Database

--- a/lib/fast_gettext.rb
+++ b/lib/fast_gettext.rb
@@ -11,6 +11,7 @@ module FastGettext
 
   LOCALE_REX =  /^[a-z]{2,3}$|^[a-z]{2,3}_[A-Z]{2,3}$/
   NAMESPACE_SEPARATOR = '|'
+  CONTEXT_SEPARATOR = '\000'
 
   # users should not include FastGettext, since this would contaminate their namespace
   # rather use

--- a/spec/fast_gettext/translation_spec.rb
+++ b/spec/fast_gettext/translation_spec.rb
@@ -61,7 +61,12 @@ describe FastGettext::Translation do
     it "translates pluralized" do
       n_('Axis','Axis',1).should == 'Achse'
       n_('Axis','Axis',2).should == 'Achsen'
+      n_('Axis','Axis',3).should == 'Achsen'
       n_('Axis','Axis',0).should == 'Achsen'
+    end
+
+    it "works with an array of keys" do
+      n_('Axis','Axis',2).should == 'Achsen'      
     end
 
     describe "pluralisations rules" do
@@ -141,13 +146,33 @@ describe FastGettext::Translation do
   end
 
   describe :ns_ do
-    it "translates whith namespace" do
+    it "translates plural with namespace" do
+      ns_('Fruit|Apple','Apples',1).should == 'Apple'
+      ns_('Fruit|Apple','Apples',2).should == 'Apples'
+      ns_('Fruit|Apple','Apples',3).should == 'Apples'
+    end
+
+    it "translates pural with double namespace" do
+      # This behavior does not match gettext but
+      # let's make sure it continues to work as to not introduce
+      # a breaking change.
       ns_('Fruit|Apple','Fruit|Apples',2).should == 'Apples'
     end
 
     it "returns block when specified" do
       ns_('not found'){:block}.should == :block
       ns_('not found'){nil}.should be_nil
+    end
+  end
+
+  describe :np_ do
+    it "translates whith namespace" do
+      np_('Fruit','Apple','Apples',2).should == 'Apples'
+    end
+
+    it "returns block when specified" do
+      np_('not','found'){:block}.should == :block
+      np_('not','found'){nil}.should be_nil
     end
   end
 
@@ -321,7 +346,7 @@ describe FastGettext::Translation do
       before do
         #singular cache keys
         FastGettext.cache['xxx'] = '1'
-        FastGettext.cache['zzz|qqq'] = '3'
+        FastGettext.cache['zzz\000qqq'] = '3'
 
         #plural cache keys
         FastGettext.cache['||||xxx'] = ['1','2']

--- a/spec/fast_gettext/translation_spec.rb
+++ b/spec/fast_gettext/translation_spec.rb
@@ -66,7 +66,7 @@ describe FastGettext::Translation do
     end
 
     it "works with an array of keys" do
-      n_('Axis','Axis',2).should == 'Achsen'      
+      n_(['Axis','Axis'],2).should == 'Achsen'      
     end
 
     describe "pluralisations rules" do


### PR DESCRIPTION
To match ruby-gettext:

* Adds the `pn_()` method
* Adds support for passing keys into `n_()` as a array
* Adds longhand aliases like `gettext` for `_()`, `ngettext()` for `n_()`, etc

Updates readme with more usage examples for standard translation methods.