### PR TITLE
p_ methods default separator is "\u0004"

### DIFF
--- a/lib/fast_gettext.rb
+++ b/lib/fast_gettext.rb
@@ -11,7 +11,7 @@ module FastGettext
 
   LOCALE_REX =  /^[a-z]{2,3}$|^[a-z]{2,3}_[A-Z]{2,3}$/
   NAMESPACE_SEPARATOR = '|'
-  CONTEXT_SEPARATOR = '\000'
+  CONTEXT_SEPARATOR = "\u0004"
 
   # users should not include FastGettext, since this would contaminate their namespace
   # rather use

--- a/lib/fast_gettext.rb
+++ b/lib/fast_gettext.rb
@@ -11,6 +11,7 @@ module FastGettext
 
   LOCALE_REX =  /^[a-z]{2,3}$|^[a-z]{2,3}_[A-Z]{2,3}$/
   NAMESPACE_SEPARATOR = '|'
+  CONTEXT_SEPARATOR = '\000'
 
   # users should not include FastGettext, since this would contaminate their namespace
   # rather use

--- a/lib/fast_gettext/translation.rb
+++ b/lib/fast_gettext/translation.rb
@@ -42,11 +42,11 @@ module FastGettext
       end
     end
 
-    #translate with namespace, use namespect to find key
+    #translate with namespace, use namespace to find key
     # 'Car','Tire' -> Tire if no translation could be found
     # p_('Car','Tire') <=> s_('Car|Tire')
     def p_(namespace, key, separator=nil, &block)
-      msgid = "#{namespace}#{separator||NAMESPACE_SEPARATOR}#{key}"
+      msgid = "#{namespace}#{separator||CONTEXT_SEPARATOR}#{key}"
       FastGettext.cached_find(msgid) or (block ? block.call : key)
     end
 

--- a/spec/fast_gettext/translation_spec.rb
+++ b/spec/fast_gettext/translation_spec.rb
@@ -321,7 +321,7 @@ describe FastGettext::Translation do
       before do
         #singular cache keys
         FastGettext.cache['xxx'] = '1'
-        FastGettext.cache['zzz|qqq'] = '3'
+        FastGettext.cache['zzz\000qqq'] = '3'
 
         #plural cache keys
         FastGettext.cache['||||xxx'] = ['1','2']

--- a/spec/fast_gettext/translation_spec.rb
+++ b/spec/fast_gettext/translation_spec.rb
@@ -321,7 +321,7 @@ describe FastGettext::Translation do
       before do
         #singular cache keys
         FastGettext.cache['xxx'] = '1'
-        FastGettext.cache['zzz\000qqq'] = '3'
+        FastGettext.cache["zzz\u0004qqq"] = '3'
 
         #plural cache keys
         FastGettext.cache['||||xxx'] = ['1','2']


### PR DESCRIPTION
The vendored po file parser uses `\000` to namespace msgctxt in p_ methods