### PR TITLE
Update readme and add method aliases to match ruby_gettext

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,11 +1,11 @@
 1.6.0 -- Remove restrictions around yaml file names
 1.1.0 -- translations are no longer eager loaded for improved startup performance, pass `eager_load: true` to preload for example in preforked web server
 1.0.0 -- do not enforce attr_accessible unless ProtectedAttributes are loaded
-0.9.0 -- reworked internals of caching to be plugable
+0.9.0 -- reworked internals of caching to be pluggable
 0.7.0 -- set_locale resets to default locale if none of the available locales was tried to set
-0.6.0 -- plurals use singular translations as fallack e.g. you translated 'Axis' then n_('Axis','Axis',1) would return the translation for 'Axis' if no plural translation was found
+0.6.0 -- plurals use singular translations as fallback e.g. you translated 'Axis' then n_('Axis','Axis',1) would return the translation for 'Axis' if no plural translation was found
 0.4.14 -- "" is translated as "", not as gettext meta information
-0.4.0 -- pluralisation_rules is no longer stored in each repository, only retrived. Added Chain and Logger repository.
+0.4.0 -- pluralisation_rules is no longer stored in each repository, only retrieved. Added Chain and Logger repository.
 0.3.6 -- FastGettext.default_locale=
 0.3.5 -- FastGettext.default_text_domain=
 0.3.4 -- Exceptions are thrown, not returned when translating without text domain

--- a/Readme.md
+++ b/Readme.md
@@ -92,14 +92,81 @@ FastGettext.locale = 'de'
 
 ### 4. Start translating
 
-```Ruby
+FastGetText supports all the translation methods of [ruby-gettext](http://github.com/ruby-gettext/gettext) with added support for block defaults.
+
+#### `_()` or `gettext()`: basic translation
+
+```ruby
 include FastGettext::Translation
-_('Car') == 'Auto'
-_('not-found') == 'not-found'
-s_('Namespace|not-found') == 'not-found'
-n_('Axis','Axis',3) == 'Achsen' #German plural of Axis
-_('Hello %{name}!') % {name: "Pete"} == 'Hello Pete!'
+_('Car') == 'Auto'             # found translation for 'Car'
+_('not-found') == 'not-found'  # The msgid is returned by default
 ```
+
+#### `n_()` or `ngettext()`: pluralization
+
+```ruby
+n_('Car','Cars',1) == 'Auto'
+n_('Car','Cars',2) == 'Autos' #German plural of Cars
+```
+
+You'll often want to interpolate the results of `n_()` using ruby builtin `%` operator.
+
+```ruby
+n_('Car','#{n} Cars',2) % { n: count } == '2 Autos'
+```
+
+
+#### `p_()` or `pgettext()`: context-aware
+
+```ruby
+p_('File','Open') == "öffnen"
+p_('Context','not-found') == 'not-found'
+```
+
+#### `s_()` or `sgetext()`: without context
+
+```ruby
+s_('File|Open') == "öffnen"
+s_('Context|not-found') == 'not-found'
+```
+
+The difference between `s_()` and `p_()` is largely based on how the translations
+are stored. Your preference will be based on your workflow and translation editing
+tools.
+
+#### `pn_()` or `pngettext()`: context-aware pluralized
+
+```ruby
+pn_('Fruit','Apple','Apples', 3) == 'Äpfel'
+pn_('Fruit','Apple','Apples', 1) == 'Apfel'
+```
+
+#### `sn_()` or `sngettext()`: without context pluralized
+
+```ruby
+sn_('Fruit|Apple','Apples', 3) == 'Äpfel'
+sn_('Fruit|Apple','Apples', 1) == 'Apfel'
+```
+
+#### `N_()` and `Nn_()`: make dynamic translations available to the parser.
+
+In many instances, your strings will not be found the by the ruby-parse. These methods
+allow for those strings to be discovered.
+
+```
+N_("active"); N_("inactive"); N_("paused") # possible value of status for parser to find.
+Nn_("active","inactive","paused")          # alternative method
+_("Your account is #{account_state}.") % { account_state: status }
+```
+
+#### Block defaults
+
+All the translation methods also support a block default, a feature not provided by ruby-gettext
+
+```ruby
+_('not-found'){ "alternative default" } == alternate default
+```
+
 
 
 Managing translations
@@ -113,7 +180,7 @@ Tell Gettext where your .mo or .po files lie, e.g. for locale/de/my_app.po and l
 FastGettext.add_text_domain('my_app', path: 'locale')
 ```
 
-Use the [original GetText](http://github.com/mutoh/gettext) to create and manage po/mo-files.
+Use the [original GetText](http://github.com/ruby-gettext/gettext) to create and manage po/mo-files.
 (Work on a po/mo parser & reader that is easier to use has started, contributions welcome @ [get_pomo](http://github.com/grosser/get_pomo) )
 
 ### Database

--- a/Readme.md
+++ b/Readme.md
@@ -185,7 +185,7 @@ Use the [original GetText](http://github.com/ruby-gettext/gettext) to create and
 
 ### Database
 [Example migration for ActiveRecord](http://github.com/grosser/fast_gettext/blob/master/examples/db/migration.rb)<br/>
-The default plural seperator is `||||` but you may overwrite it (or suggest a better one..).
+The default plural separator is `||||` but you may overwrite it (or suggest a better one..).
 
 This is usable with any model DataMapper/Sequel or any other(non-database) backend, the only thing you need to do is respond to the self.translation(key, locale) call.
 If you want to use your own models, have a look at the [default models](http://github.com/grosser/fast_gettext/tree/master/lib/fast_gettext/translation_repository/db_models) to see what you want/need to implement.
@@ -197,7 +197,7 @@ Rails
 Try the [gettext_i18n_rails plugin](http://github.com/grosser/gettext_i18n_rails), it simplifies the setup.<br/>
 Try the [translation_db_engine](http://github.com/grosser/translation_db_engine), to manage your translations in a db.
 
-Setting `available_locales`,`text_domain` or `locale` will not work inside the `evironment.rb`,
+Setting `available_locales`,`text_domain` or `locale` will not work inside the `environment.rb`,
 since it runs in a different thread then e.g. controllers, so set them inside your application_controller.
 
 ```Ruby
@@ -246,7 +246,7 @@ If you only use one text domain, setting `FastGettext.default_text_domain = 'app
 is sufficient and no more `text_domain=` is needed
 
 ### default_locale
-If the simple rule of "first `availble_locale` or 'en'" is not suficcient for you, set `FastGettext.default_locale = 'de'`.
+If the simple rule of "first `available_locale` or 'en'" is not sufficient for you, set `FastGettext.default_locale = 'de'`.
 
 ### default_available_locales
 Fallback when no available_locales are set

--- a/lib/fast_gettext/translation.rb
+++ b/lib/fast_gettext/translation.rb
@@ -20,6 +20,7 @@ module FastGettext
     def _(key, &block)
       FastGettext.cached_find(key) or (block ? block.call : key)
     end
+    alias :gettext :_
 
     #translate pluralized
     # some languages have up to 4 plural forms...
@@ -41,6 +42,7 @@ module FastGettext
         block ? block.call : keys.last
       end
     end
+    alias :ngettext :n_
 
     #translate with namespace, use namespace to find key
     # 'Car','Tire' -> Tire if no translation could be found
@@ -49,6 +51,7 @@ module FastGettext
       msgid = "#{namespace}#{separator||CONTEXT_SEPARATOR}#{key}"
       FastGettext.cached_find(msgid) or (block ? block.call : key)
     end
+    alias :pgettext :p_
 
     #translate, but discard namespace if nothing was found
     # Car|Tire -> Tire if no translation could be found
@@ -56,6 +59,7 @@ module FastGettext
       translation = FastGettext.cached_find(key) and return translation
       block ? block.call : key.split(separator||NAMESPACE_SEPARATOR).last
     end
+    alias :sgettext :s_
 
     #tell gettext: this string need translation (will be found during parsing)
     def N_(translate)
@@ -72,12 +76,14 @@ module FastGettext
       # block is called once again to compare result
       block && translation == block.call ? translation : translation.split(NAMESPACE_SEPARATOR).last
     end
+    alias :nsgettext :ns_
 
     def np_(context, key, *args, &block)
       options = (args.last.is_a? Hash) ? args.pop : {}
       nargs = ["#{context}#{options[:separator]||CONTEXT_SEPARATOR}#{key}"] + args
       n_(*nargs){nil} or (block ? block.call : key)
     end
+    alias :npgettext :np_
   end
 
   # this module should be included for multi-domain support

--- a/spec/fast_gettext/translation_spec.rb
+++ b/spec/fast_gettext/translation_spec.rb
@@ -141,7 +141,16 @@ describe FastGettext::Translation do
   end
 
   describe :ns_ do
-    it "translates whith namespace" do
+    it "translates plural with namespace" do
+      ns_('Fruit|Apple','Apples',1).should == 'Apple'
+      ns_('Fruit|Apple','Apples',2).should == 'Apples'
+      ns_('Fruit|Apple','Apples',3).should == 'Apples'
+    end
+
+    it "translates pural with double namespace" do
+      # This behavior does not match gettext but
+      # let's make sure it continues to work as to not introduce
+      # a breaking change.
       ns_('Fruit|Apple','Fruit|Apples',2).should == 'Apples'
     end
 


### PR DESCRIPTION
Achieves near parity with ruby-gettext methods