### PR TITLE
Initialize @data variable to avoid warnings

### DIFF
--- a/lib/fast_gettext/mo_file.rb
+++ b/lib/fast_gettext/mo_file.rb
@@ -11,6 +11,7 @@ module FastGettext
     # file => path or FastGettext::GetText::MOFile
     def initialize(file, options = {})
       @filename = file
+      @data = nil
       load_data if options[:eager_load]
     end
 


### PR DESCRIPTION
Running our project with warnings enabled for rspec creates an unfortunate number of these warnings:

`warning: instance variable @data not initialized`

This just sets it to nil in the initializer.