### PR TITLE
Db class should not require ActiveRecord unless db_models are loaded

### DIFF
--- a/lib/fast_gettext/translation_repository/db.rb
+++ b/lib/fast_gettext/translation_repository/db.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'active_record'
 module FastGettext
   module TranslationRepository
     # Responsibility:
@@ -51,6 +50,7 @@ module FastGettext
       end
 
       def self.require_models
+	require 'active_record'
         folder = "fast_gettext/translation_repository/db_models"
         require "#{folder}/translation_key"
         require "#{folder}/translation_text"


### PR DESCRIPTION
Proposal of fix for #120. 

Db adapter doesn't depend on ActiveRecord as long as it doesn't use built-in models, so ActiveRecord should be loaded alongside them.

Unfortunately I wasn't able to test it with ActiveRecord application.