### PR TITLE
Restore compatibility with older Rubies

### DIFF
--- a/lib/fast_gettext/storage.rb
+++ b/lib/fast_gettext/storage.rb
@@ -172,7 +172,7 @@ module FastGettext
       locales = locales.to_s.gsub(/\s/, '')
       found = [[]]
       locales.split(',').each do |part|
-        if /;q=/.match?(part) # contains language and weight ?
+        if part.include? ';q=' # contains language and weight ?
           found.last << part.split(/;q=/)
           found.last.flatten!
           found << []


### PR DESCRIPTION
Hi!

Commit 08599fcec9d506ecce2f35db4a3a60af46f9420c, for some reason, went from using `=~` to using `match?`, which is not supported by older Rubies.  That broke several of our applications.

I venture we can both be happy by avoiding Regexes completely.

Cheers!