### PR TITLE
Enable bundler caching for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+cache: bundler
 script: "bundle exec rake spec"
 bundler_args: --jobs 4 --quiet --path vendor/bundle # not --deployment
 rvm:


### PR DESCRIPTION
Would be interested to know why bundler cache hasn't been enabled on Travis. Thank you.