### PR TITLE
Drop taint checking mechanism related code

### DIFF
--- a/lib/fast_gettext/translation_repository/base.rb
+++ b/lib/fast_gettext/translation_repository/base.rb
@@ -47,7 +47,7 @@ module FastGettext
         Dir[File.join(path, '*')].each do |locale_folder|
           next unless File.basename(locale_folder) =~ LOCALE_REX
 
-          file = File.join(locale_folder, relative_file_path).untaint
+          file = File.join(locale_folder, relative_file_path)
           next unless File.exist? file
 
           locale = File.basename(locale_folder)

--- a/spec/cases/safe_mode_can_handle_locales.rb
+++ b/spec/cases/safe_mode_can_handle_locales.rb
@@ -1,5 +1,0 @@
-$LOAD_PATH.unshift 'lib'
-require 'fast_gettext'
-$SAFE = 1
-rep = FastGettext::TranslationRepository.build('safe_test',:path=>File.join('spec','locale'))
-print rep.is_a?(FastGettext::TranslationRepository::Mo)

--- a/spec/fast_gettext/translation_repository/merge_spec.rb
+++ b/spec/fast_gettext/translation_repository/merge_spec.rb
@@ -137,9 +137,4 @@ describe 'FastGettext::TranslationRepository::Merge' do
       end
     end
   end
-
-  it "can work in SAFE mode" do
-    pending
-    `ruby spec/cases/safe_mode_can_handle_locales.rb 2>&1`.should == 'true'
-  end
 end

--- a/spec/fast_gettext/translation_repository/mo_spec.rb
+++ b/spec/fast_gettext/translation_repository/mo_spec.rb
@@ -52,9 +52,4 @@ describe 'FastGettext::TranslationRepository::Mo' do
     rep['car'].should == 'Test'#just check it is loaded correctly
     rep.pluralisation_rule.call(2).should == 3
   end
-
-  it "can work in SAFE mode" do
-    pending
-    `ruby spec/cases/safe_mode_can_handle_locales.rb 2>&1`.should == 'true'
-  end
 end


### PR DESCRIPTION
Taint checking has been deprecated starting Ruby 2.7: https://bugs.ruby-lang.org/issues/16131.   
    
As a result, this gem and other gems using it (`gettext_i18n_rails`) produce too many noise warnings on Ruby 3 builds.    
Example in our project CI [GitLab]: https://gitlab.com/gitlab-org/gitlab/-/jobs/1524901589#L341   

We consider follow the deprecation of the taint checking logic.