### PR TITLE
Use update instead of update_attributes

### DIFF
--- a/spec/fast_gettext/translation_repository/db_spec.rb
+++ b/spec/fast_gettext/translation_repository/db_spec.rb
@@ -112,6 +112,6 @@ describe FastGettext::TranslationRepository::Db do
   it "expires the cache when updated" do
     FastGettext.should_receive(:expire_cache_for).with('car')
     translation_text = create_translation 'car', 'Auto'
-    translation_text.update_attributes :text => 'Autobot'
+    translation_text.update :text => 'Autobot'
   end
 end


### PR DESCRIPTION
`update_attributes` has been deprecated and
removed in Rails 6 and onward, thereby
making this test fail with newer Rails.

Fixes: #135