### PR TITLE
Use RuboCop::Packaging to help downstream

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,6 @@
+require:
+  - rubocop-packaging
+
 AllCops:
   TargetRubyVersion: 2.5 # keep in sync with minimum version
   Exclude:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,7 +18,7 @@ GEM
       minitest (~> 5.1)
       tzinfo (~> 1.1)
     arel (9.0.0)
-    ast (2.4.0)
+    ast (2.4.2)
     bump (0.7.0)
     concurrent-ruby (1.1.3)
     diff-lcs (1.3)
@@ -26,16 +26,16 @@ GEM
       parallel_tests (>= 1.3.7)
     i18n (1.2.0)
       concurrent-ruby (~> 1.0)
-    jaro_winkler (1.5.1)
     minitest (5.11.3)
-    parallel (1.12.1)
+    parallel (1.21.0)
     parallel_tests (2.27.0)
       parallel
-    parser (2.5.3.0)
-      ast (~> 2.4.0)
-    powerpack (0.1.2)
-    rainbow (3.0.0)
+    parser (3.1.0.0)
+      ast (~> 2.4.1)
+    rainbow (3.1.1)
     rake (12.3.2)
+    regexp_parser (2.2.0)
+    rexml (3.2.5)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
       rspec-expectations (~> 3.8.0)
@@ -49,21 +49,26 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.8.0)
     rspec-support (3.8.0)
-    rubocop (0.61.1)
-      jaro_winkler (~> 1.5.1)
+    rubocop (1.25.0)
       parallel (~> 1.10)
-      parser (>= 2.5, != 2.5.1.1)
-      powerpack (~> 0.1)
+      parser (>= 3.1.0.0)
       rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml
+      rubocop-ast (>= 1.15.1, < 2.0)
       ruby-progressbar (~> 1.7)
-      unicode-display_width (~> 1.4.0)
-    ruby-progressbar (1.10.0)
+      unicode-display_width (>= 1.4.0, < 3.0)
+    rubocop-ast (1.15.1)
+      parser (>= 3.0.1.1)
+    rubocop-packaging (0.5.1)
+      rubocop (>= 0.89, < 2.0)
+    ruby-progressbar (1.11.0)
     single_cov (1.3.0)
     sqlite3 (1.3.13)
     thread_safe (0.3.6)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
-    unicode-display_width (1.4.0)
+    unicode-display_width (2.1.0)
 
 PLATFORMS
   ruby
@@ -77,6 +82,7 @@ DEPENDENCIES
   rake
   rspec
   rubocop
+  rubocop-packaging
   single_cov
   sqlite3
 

--- a/fast_gettext.gemspec
+++ b/fast_gettext.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new name, FastGettext::VERSION do |s|
   s.add_development_dependency 'i18n'
   s.add_development_dependency 'bump'
   s.add_development_dependency 'rubocop'
+  s.add_development_dependency 'rubocop-packaging'
   s.add_development_dependency 'single_cov'
   s.add_development_dependency 'forking_test_runner'
 end

--- a/gemfiles/rails52.gemfile.lock
+++ b/gemfiles/rails52.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    fast_gettext (2.1.0)
+    fast_gettext (2.2.0)
 
 GEM
   remote: https://rubygems.org/
@@ -48,7 +48,7 @@ GEM
       minitest (~> 5.1)
       tzinfo (~> 1.1)
     arel (9.0.0)
-    ast (2.4.0)
+    ast (2.4.2)
     builder (3.2.4)
     bump (0.7.0)
     concurrent-ruby (1.1.9)
@@ -61,7 +61,6 @@ GEM
       activesupport (>= 5.0)
     i18n (1.8.10)
       concurrent-ruby (~> 1.0)
-    jaro_winkler (1.5.1)
     loofah (2.12.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -76,12 +75,11 @@ GEM
     nokogiri (1.12.3)
       mini_portile2 (~> 2.6.1)
       racc (~> 1.4)
-    parallel (1.12.1)
+    parallel (1.21.0)
     parallel_tests (2.31.0)
       parallel
-    parser (2.5.3.0)
-      ast (~> 2.4.0)
-    powerpack (0.1.2)
+    parser (3.1.0.0)
+      ast (~> 2.4.1)
     racc (1.5.2)
     rack (2.2.3)
     rack-test (1.1.0)
@@ -110,8 +108,10 @@ GEM
       method_source
       rake (>= 0.8.7)
       thor (>= 0.19.0, < 2.0)
-    rainbow (3.0.0)
+    rainbow (3.1.1)
     rake (13.0.6)
+    regexp_parser (2.2.0)
+    rexml (3.2.5)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
       rspec-expectations (~> 3.8.0)
@@ -125,15 +125,20 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.8.0)
     rspec-support (3.8.0)
-    rubocop (0.61.1)
-      jaro_winkler (~> 1.5.1)
+    rubocop (1.25.0)
       parallel (~> 1.10)
-      parser (>= 2.5, != 2.5.1.1)
-      powerpack (~> 0.1)
+      parser (>= 3.1.0.0)
       rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml
+      rubocop-ast (>= 1.15.1, < 2.0)
       ruby-progressbar (~> 1.7)
-      unicode-display_width (~> 1.4.0)
-    ruby-progressbar (1.10.0)
+      unicode-display_width (>= 1.4.0, < 3.0)
+    rubocop-ast (1.15.1)
+      parser (>= 3.0.1.1)
+    rubocop-packaging (0.5.1)
+      rubocop (>= 0.89, < 2.0)
+    ruby-progressbar (1.11.0)
     single_cov (1.3.2)
     sprockets (4.0.2)
       concurrent-ruby (~> 1.0)
@@ -147,7 +152,7 @@ GEM
     thread_safe (0.3.6)
     tzinfo (1.2.9)
       thread_safe (~> 0.1)
-    unicode-display_width (1.4.0)
+    unicode-display_width (2.1.0)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -165,6 +170,7 @@ DEPENDENCIES
   rake
   rspec
   rubocop
+  rubocop-packaging
   single_cov
   sqlite3
 


### PR DESCRIPTION
Hello, @grosser,

I maintain this library in Debian and in Ubuntu. :D

To help downstreams package and maintain this, we wrote rubocop-packaging, that is widely used and helps us in catching problems (if any) at an early stage and helps automatically fix them.

This adds `rubocop-packaging` as an extension that'll help in maintaining this. Let me know what you think?

Thanks, again, for all your work! \o/