### PR TITLE
Load empty mo file only once

### DIFF
--- a/lib/fast_gettext/mo_file.rb
+++ b/lib/fast_gettext/mo_file.rb
@@ -44,7 +44,7 @@ module FastGettext
     end
 
     def self.empty
-      MoFile.new(File.join(File.dirname(__FILE__), 'vendor', 'empty.mo'))
+      @empty ||= MoFile.new(File.join(__dir__, 'vendor', 'empty.mo'), eager_load: true).freeze
     end
 
     private

--- a/spec/fast_gettext/mo_file_spec.rb
+++ b/spec/fast_gettext/mo_file_spec.rb
@@ -63,4 +63,37 @@ describe FastGettext::MoFile do
     end
 
   end
+
+  describe ".empty" do
+    let(:path) do
+      File.expand_path("../../lib/fast_gettext/vendor/empty.mo", __dir__)
+    end
+
+    before do
+      # clear the ivar cache
+      described_class.remove_instance_variable(:@empty) if described_class.instance_variable_defined?(:@empty)
+    end
+
+    it "is frozen" do
+      described_class.empty.should be_frozen
+    end
+
+    it "has no translations" do
+      described_class.empty["foo"].should be_nil
+      described_class.empty["bar"].should be_nil
+    end
+
+    it "is cached" do
+      described_class.empty.object_id.should eq(described_class.empty.object_id)
+    end
+
+    it "loads empty mo file eagerly only once" do
+      FastGettext::GetText::MOFile.should_receive(:open).once.with(path, "UTF-8").and_call_original
+
+      described_class.empty
+      described_class.empty
+      described_class.empty["foo"]
+      described_class.empty["bar"]
+    end
+  end
 end


### PR DESCRIPTION
This reduces the amount of reads when translating strings for the default locale. Default locales it does not have a po file to load and fall back to an empty mo file loading `empty.mo` each time.

Previously, the following calls result in reading the empty mo file over and over again:

```ruby
  # default locale - no translations available/loaded
  _('foo') # => reads empty mo file
  _('foo') # => second call is then cached
  _('bar') # => reads empty mo file
  _('baz') # => reads empty mo file
```

Now, it's:

```ruby
  # default locale - no translations available/loaded
  _('foo') # => reads empty mo file
  _('foo') # => second call is then cached
  _('bar') # => uses ivar cache
  _('baz') # => uses ivar cache
```

See also https://gitlab.com/gitlab-org/gitlab/-/issues/391840.

## Example

1. Apply this spec patch:

```diff
diff --git a/lib/fast_gettext/mo_file.rb b/lib/fast_gettext/mo_file.rb
index f11210e..7b25edf 100644
--- a/lib/fast_gettext/mo_file.rb
+++ b/lib/fast_gettext/mo_file.rb
@@ -50,6 +50,7 @@ module FastGettext
     private
 
     def load_data
+      p :LOAD_EMPTY if @filename.include?("empty.mo")
       @data =
         if @filename.is_a? FastGettext::GetText::MOFile
           @filename
diff --git a/spec/fast_gettext/translation_spec.rb b/spec/fast_gettext/translation_spec.rb
index 7d67599..42a682b 100644
--- a/spec/fast_gettext/translation_spec.rb
+++ b/spec/fast_gettext/translation_spec.rb
@@ -17,6 +17,9 @@ describe FastGettext::Translation do
 
     it "does not translate" do
       _('car').should == 'car'
+      %w[foo bar baz].each do |word|
+        _(word).should == word
+      end
     end
 
     it "does not translate plurals" do
```

2. Run `bundle exec rspec spec/fast_gettext/translation_spec.rb -e "does not translate"` on `master`.

`empty.mo` is loaded multiple times:

```
Run options: include {:full_description=>/does\ not\ translate/}
:LOAD_EMPTY
:LOAD_EMPTY
:LOAD_EMPTY
:LOAD_EMPTY
.:LOAD_EMPTY
:LOAD_EMPTY
:LOAD_EMPTY
.

Finished in 0.00497 seconds (files took 0.16102 seconds to load)
2 examples, 0 failures
```

3. Run `bundle exec rspec spec/fast_gettext/translation_spec.rb -e "does not translate"` on this branch.

```
Run options: include {:full_description=>/does\ not\ translate/}
:LOAD_EMPTY
..

Finished in 0.00494 seconds (files took 0.14154 seconds to load)
2 examples, 0 failures
```

`empty.mo` is only loaded once.