### PR TITLE
Add explicit dependency to `prime`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -95,4 +95,4 @@ DEPENDENCIES
   sqlite3
 
 BUNDLED WITH
-   2.1.4
+   2.3.27

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     fast_gettext (2.3.0)
+      prime
 
 GEM
   remote: https://rubygems.org/
@@ -24,6 +25,7 @@ GEM
     diff-lcs (1.3)
     forking_test_runner (1.3.0)
       parallel_tests (>= 1.3.7)
+    forwardable (1.3.3)
     i18n (1.2.0)
       concurrent-ruby (~> 1.0)
     mini_portile2 (2.8.1)
@@ -33,6 +35,9 @@ GEM
       parallel
     parser (3.1.0.0)
       ast (~> 2.4.1)
+    prime (0.1.2)
+      forwardable
+      singleton
     rainbow (3.1.1)
     rake (12.3.2)
     regexp_parser (2.2.0)
@@ -65,6 +70,7 @@ GEM
       rubocop (>= 0.89, < 2.0)
     ruby-progressbar (1.11.0)
     single_cov (1.3.0)
+    singleton (0.2.0)
     sqlite3 (1.6.0)
       mini_portile2 (~> 2.8.0)
     thread_safe (0.3.6)

--- a/fast_gettext.gemspec
+++ b/fast_gettext.gemspec
@@ -11,6 +11,7 @@ Gem::Specification.new name, FastGettext::VERSION do |s|
   s.files = Dir["{lib/**/*.{rb,mo,rdoc},Readme.md,CHANGELOG,LICENSE}"]
   s.licenses = ["MIT", "Ruby"]
   s.required_ruby_version = '>= 2.5.0'
+  s.add_runtime_dependency 'prime'
 
   s.add_development_dependency 'rake'
   s.add_development_dependency 'sqlite3'

--- a/gemfiles/rails52.gemfile.lock
+++ b/gemfiles/rails52.gemfile.lock
@@ -1,7 +1,8 @@
 PATH
   remote: ..
   specs:
-    fast_gettext (2.2.0)
+    fast_gettext (2.3.0)
+      prime
 
 GEM
   remote: https://rubygems.org/
@@ -57,6 +58,7 @@ GEM
     erubi (1.10.0)
     forking_test_runner (1.6.0)
       parallel_tests (>= 1.3.7)
+    forwardable (1.3.3)
     globalid (0.5.2)
       activesupport (>= 5.0)
     i18n (1.8.10)
@@ -71,7 +73,7 @@ GEM
     mini_mime (1.1.1)
     mini_portile2 (2.6.1)
     minitest (5.14.4)
-    nio4r (2.5.8)
+    nio4r (2.7.3)
     nokogiri (1.12.3)
       mini_portile2 (~> 2.6.1)
       racc (~> 1.4)
@@ -80,6 +82,9 @@ GEM
       parallel
     parser (3.1.0.0)
       ast (~> 2.4.1)
+    prime (0.1.2)
+      forwardable
+      singleton
     racc (1.5.2)
     rack (2.2.3)
     rack-test (1.1.0)
@@ -140,6 +145,7 @@ GEM
       rubocop (>= 0.89, < 2.0)
     ruby-progressbar (1.11.0)
     single_cov (1.3.2)
+    singleton (0.2.0)
     sprockets (4.0.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -175,4 +181,4 @@ DEPENDENCIES
   sqlite3
 
 BUNDLED WITH
-   2.1.4
+   2.3.27

--- a/lib/fast_gettext/vendor/mofile.rb
+++ b/lib/fast_gettext/vendor/mofile.rb
@@ -20,6 +20,7 @@
 # Changes: Namespaced + uses FastGettext::Icvon
 
 require 'stringio'
+require 'prime'
 
 module FastGettext
   module GetText
@@ -167,19 +168,8 @@ module FastGettext
         ('1' * number) !~ /^1?$|^(11+?)\1+$/
       end
 
-      begin
-        require 'prime'
-        def next_prime(seed)
-          Prime.instance.find{|x| x > seed }
-        end
-      rescue LoadError
-        def next_prime(seed)
-          require 'mathn'
-          prime = Prime.new
-          while current = prime.succ
-            return current if current > seed
-          end
-        end
+      def next_prime(seed)
+        Prime.instance.find{|x| x > seed }
       end
 
       HASHWORDBITS = 32


### PR DESCRIPTION
The `prime` gem has been extracted from Ruby core into a gem.

Starting with Ruby 3.4.0, it will no longer be bundled with Ruby, so it requires an explicit dependency. Ruby 3.3.0+ display a warning due to this:

```
/usr/local/bundle/gems/bootsnap-1.18.3/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:27: warning: prime was loaded from the standard library, but is not part of the default gems since Ruby 3.1.0. Add prime to your Gemfile or
gemspec. Also contact author of fast_gettext-2.3.0 to add prime into its gemspec.
```

I also removed the fallback that uses `mathn`, as `mathn` is deprecated and not recommended to use. The `prime` gem supports Ruby 2.5.0+, same as this gem, so it should not break compatibility.