### PR TITLE
Mark mutable strings as mutable

### DIFF
--- a/lib/fast_gettext/vendor/mofile.rb
+++ b/lib/fast_gettext/vendor/mofile.rb
@@ -47,8 +47,8 @@ module FastGettext
         :trans_sysdep_tab_offset
       end
 
-      MAGIC_BIG_ENDIAN    = "\x95\x04\x12\xde"
-      MAGIC_LITTLE_ENDIAN = "\xde\x12\x04\x95"
+      MAGIC_BIG_ENDIAN    = +"\x95\x04\x12\xde"
+      MAGIC_LITTLE_ENDIAN = +"\xde\x12\x04\x95"
       if "".respond_to?(:force_encoding)
         MAGIC_BIG_ENDIAN.force_encoding("ASCII-8BIT")
         MAGIC_LITTLE_ENDIAN.force_encoding("ASCII-8BIT")


### PR DESCRIPTION
Running the test suite with RUBYOPT="--enable-frozen-string-literal" simulates Ruby's future behavior having frozen string on by default. This fixed the error that happens with this option enabled by marking two strings which are mutated as mutable with the `+` operator.