### PR TITLE
Convert String#% to Ruby 1.9+ behavior with option use maintain current behavior

### DIFF
--- a/lib/fast_gettext.rb
+++ b/lib/fast_gettext.rb
@@ -28,6 +28,21 @@ module FastGettext
     translation_repositories[name] = TranslationRepository.build(name, options)
   end
 
+  def self.allow_invalid_keys!
+    eval(<<CODE)
+class ::String
+  alias :_fast_gettext_old_format_m :%
+  def %(*args)
+    begin
+      _fast_gettext_old_format_m(*args)
+    rescue KeyError
+      self
+    end
+  end
+end
+CODE
+  end
+
   # some repositories know where to store their locales
   def self.locale_path
     translation_repositories[text_domain].instance_variable_get(:@options)[:path]

--- a/lib/fast_gettext/vendor/string.rb
+++ b/lib/fast_gettext/vendor/string.rb
@@ -58,19 +58,3 @@ rescue ArgumentError
     end
   end
 end
-
-# 1.9.1 if you misspell a %{key} your whole page would blow up, no thanks...
-begin
-  ("%{b}" % {:a=>'b'})
-rescue KeyError
-  class String
-    alias :_fast_gettext_old_format_m :%
-    def %(*args)
-      begin
-        _fast_gettext_old_format_m(*args)
-      rescue KeyError
-        self
-      end
-    end
-  end
-end

--- a/spec/fast_gettext/vendor/string_spec.rb
+++ b/spec/fast_gettext/vendor/string_spec.rb
@@ -49,7 +49,19 @@ describe String do
     end
   end
 
-  it "does not raise when key was not found" do
+  it "raise when key was not found" do
+    lambda { ("%{typo} xxx" % {:something=>1}) }.should raise_error(KeyError)
+  end
+
+  it "does not raise when key was not found if allow_invalid_keys! is enabled" do
+    FastGettext.allow_invalid_keys!
     ("%{typo} xxx" % {:something=>1}).should == "%{typo} xxx"
+
+    # cleanup
+    eval(<<CODE)
+class ::String
+  alias :% :_fast_gettext_old_format_m
+end
+CODE
   end
 end


### PR DESCRIPTION
Previously String#% was overridden on versions after Ruby 1.9 to match the 1.8 behavior where missing keys in the expanded format are ignored and not replaced. This is likely suprising behavior in modern Ruby. This removes the previous patch, but still allows overriding this behavior optionally by calling `FastGettext.allow_invalid_keys!`.

This is less surprising behavior, but still allows a migration path for people who rely on the current missing key behavior. Let me know if this seems reasonable! Thanks!