### PR TITLE
drop unused local variable in vendor/mofile.rb

### DIFF
--- a/lib/fast_gettext/vendor/mofile.rb
+++ b/lib/fast_gettext/vendor/mofile.rb
@@ -179,7 +179,6 @@ module FastGettext
       # 1986, 1987 Bell Telephone Laboratories, Inc.]
       def hash_string(str)
         hval = 0
-        i = 0
         str.each_byte do |b|
           break if b == '\0'
           hval <<= 4


### PR DESCRIPTION
a small warning, while running in `$VERBOSE` mode:
```
gems/fast_gettext-4.1.0/lib/fast_gettext/vendor/mofile.rb:182: warning: assigned but unused variable - i
```